### PR TITLE
Optimize batched multiplication for generate_triple_many.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ digest = "0.10.7"
 ecdsa = { version = "0.16.8", features = ["digest", "hazmat"] }
 elliptic-curve = { version = "0.13.5", features = ["serde"] }
 event-listener = "2.5.3"
+futures = "0.3.31"
 k256 = { version = "0.13.1", features = ["sha256", "ecdsa", "serde"], optional = true }
 magikitten = "0.2.0"
 rand_core = { version = "0.6.4", features = ["getrandom"] }

--- a/src/triples/multiplication.rs
+++ b/src/triples/multiplication.rs
@@ -1,4 +1,3 @@
-use crate::triples::batch_random_ot::{batch_random_ot_receiver_many, batch_random_ot_sender_many};
 use crate::{
     compat::CSCurve,
     constants::SECURITY_PARAMETER,
@@ -18,6 +17,7 @@ use super::{
         random_ot_extension_receiver, random_ot_extension_sender, RandomOtExtensionParams,
     },
 };
+use std::collections::VecDeque;
 
 pub async fn multiplication_sender<'a, C: CSCurve>(
     ctx: Context<'a>,
@@ -48,53 +48,9 @@ pub async fn multiplication_sender<'a, C: CSCurve>(
     let task1 = ctx.spawn(mta_sender::<C>(chan.child(3), res1, *b_i));
 
     // Step 3
-    let gamma0 = ctx.run(task0).await?;
-    let gamma1 = ctx.run(task1).await?;
+    let (gamma0, gamma1) = futures::future::join(task0, task1).await;
 
-    Ok(gamma0 + gamma1)
-}
-
-pub async fn multiplication_sender_many<'a, C: CSCurve, const N: usize>(
-    ctx: Context<'a>,
-    chan: PrivateChannel,
-    sid: &[Digest],
-    a_iv: &[C::Scalar],
-    b_iv: &[C::Scalar],
-) -> Result<Vec<C::Scalar>, ProtocolError> {
-    assert!(N > 0);
-    let mut ret = vec![];
-    // First, run a fresh batch random OT ourselves
-    let dkv = batch_random_ot_receiver_many::<C, N>(ctx.clone(), chan.child(0)).await?;
-    for i in 0..N {
-        let (delta, k) = &dkv[i];
-        let a_i = &a_iv[i];
-        let b_i = &b_iv[i];
-
-        let batch_size = C::BITS + SECURITY_PARAMETER;
-        // Step 1
-        let mut res0 = random_ot_extension_sender::<C>(
-            chan.child(1),
-            RandomOtExtensionParams {
-                sid: sid[i].as_ref(),
-                batch_size: 2 * batch_size,
-            },
-            *delta,
-            k,
-        )
-        .await?;
-        let res1 = res0.split_off(batch_size);
-
-        // Step 2
-        let task0 = ctx.spawn(mta_sender::<C>(chan.child(2), res0, *a_i));
-        let task1 = ctx.spawn(mta_sender::<C>(chan.child(3), res1, *b_i));
-
-        // Step 3
-        let gamma0 = ctx.run(task0).await?;
-        let gamma1 = ctx.run(task1).await?;
-
-        ret.push(gamma0 + gamma1);
-    }
-    Ok(ret)
+    Ok(gamma0? + gamma1?)
 }
 
 pub async fn multiplication_receiver<'a, C: CSCurve>(
@@ -126,53 +82,9 @@ pub async fn multiplication_receiver<'a, C: CSCurve>(
     let task1 = ctx.spawn(mta_receiver::<C>(chan.child(3), res1, *a_i));
 
     // Step 3
-    let gamma0 = ctx.run(task0).await?;
-    let gamma1 = ctx.run(task1).await?;
+    let (gamma0, gamma1) = futures::future::join(task0, task1).await;
 
-    Ok(gamma0 + gamma1)
-}
-
-pub async fn multiplication_receiver_many<'a, C: CSCurve, const N: usize>(
-    ctx: Context<'a>,
-    chan: PrivateChannel,
-    sid: &[Digest],
-    a_iv: &[C::Scalar],
-    b_iv: &[C::Scalar],
-) -> Result<Vec<C::Scalar>, ProtocolError> {
-    assert!(N > 0);
-    let mut ret = vec![];
-    // First, run a fresh batch random OT ourselves
-    let dkv = batch_random_ot_sender_many::<C, N>(ctx.clone(), chan.child(0)).await?;
-    for i in 0..N {
-        let (k0, k1) = &dkv[i];
-        let a_i = &a_iv[i];
-        let b_i = &b_iv[i];
-
-        let batch_size = C::BITS + SECURITY_PARAMETER;
-        // Step 1
-        let mut res0 = random_ot_extension_receiver::<C>(
-            chan.child(1),
-            RandomOtExtensionParams {
-                sid: sid[i].as_ref(),
-                batch_size: 2 * batch_size,
-            },
-            k0,
-            k1,
-        )
-        .await?;
-        let res1 = res0.split_off(batch_size);
-
-        // Step 2
-        let task0 = ctx.spawn(mta_receiver::<C>(chan.child(2), res0, *b_i));
-        let task1 = ctx.spawn(mta_receiver::<C>(chan.child(3), res1, *a_i));
-
-        // Step 3
-        let gamma0 = ctx.run(task0).await?;
-        let gamma1 = ctx.run(task1).await?;
-
-        ret.push(gamma0 + gamma1);
-    }
-    Ok(ret)
+    Ok(gamma0? + gamma1?)
 }
 
 pub async fn multiplication<C: CSCurve>(
@@ -218,36 +130,45 @@ pub async fn multiplication_many<C: CSCurve, const N: usize>(
     let av_iv_arc = Arc::new(av_iv);
     let bv_iv_arc = Arc::new(bv_iv);
     let mut tasks = Vec::with_capacity(participants.len() - 1);
-    for p in participants.others(me) {
-        let sid_arc = sid_arc.clone();
-        let av_iv_arc = av_iv_arc.clone();
-        let bv_iv_arc = bv_iv_arc.clone();
-        let fut = {
-            let ctx = ctx.clone();
-            let chan = ctx.private_channel(me, p);
-            async move {
-                if p < me {
-                    multiplication_sender_many::<C, N>(
-                        ctx,
-                        chan,
-                        sid_arc.as_slice(),
-                        av_iv_arc.as_slice(),
-                        bv_iv_arc.as_slice(),
-                    )
-                    .await
-                } else {
-                    multiplication_receiver_many::<C, N>(
-                        ctx,
-                        chan,
-                        sid_arc.as_slice(),
-                        av_iv_arc.as_slice(),
-                        bv_iv_arc.as_slice(),
-                    )
-                    .await
+    for i in 0..N {
+        let order_key_me = crate::crypto::hash(&(i, me));
+        for p in participants.others(me) {
+            let sid_arc = sid_arc.clone();
+            let av_iv_arc = av_iv_arc.clone();
+            let bv_iv_arc = bv_iv_arc.clone();
+            let fut = {
+                let ctx = ctx.clone();
+                let chan = ctx.private_channel(me, p).child(i as u64);
+                let order_key_other = crate::crypto::hash(&(i, p));
+
+                async move {
+                    // Use a deterministic but random comparison function to decide who
+                    // is the sender and who is the receiver. This allows the batched
+                    // multiplication operation to put even networking load between the
+                    // participants.
+                    if order_key_other.as_ref() < order_key_me.as_ref() {
+                        multiplication_sender::<C>(
+                            ctx,
+                            chan,
+                            sid_arc[i].as_ref(),
+                            &av_iv_arc[i],
+                            &bv_iv_arc[i],
+                        )
+                        .await
+                    } else {
+                        multiplication_receiver::<C>(
+                            ctx,
+                            chan,
+                            sid_arc[i].as_ref(),
+                            &av_iv_arc[i],
+                            &bv_iv_arc[i],
+                        )
+                        .await
+                    }
                 }
-            }
-        };
-        tasks.push(ctx.spawn(fut));
+            };
+            tasks.push(ctx.spawn(fut));
+        }
     }
     let mut outs = vec![];
     for i in 0..N {
@@ -256,12 +177,21 @@ pub async fn multiplication_many<C: CSCurve, const N: usize>(
         let out = *av_i * *bv_i;
         outs.push(out);
     }
-    for task in tasks {
-        let t = task.await?;
-        for i in 0..N {
-            outs[i] += t[i];
+
+    let mut results = futures::future::join_all(tasks)
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .collect::<VecDeque<_>>();
+
+    for i in 0..N {
+        for _ in participants.others(me) {
+            let result = results.pop_front().unwrap();
+            outs[i] += result;
         }
     }
+
     Ok(outs)
 }
 
@@ -280,6 +210,7 @@ mod test {
     };
 
     use super::multiplication;
+    use crate::triples::multiplication::multiplication_many;
 
     #[test]
     fn test_multiplication() -> Result<(), ProtocolError> {
@@ -328,6 +259,82 @@ mod test {
 
         assert_eq!(a * b, c);
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_multiplication_many() -> Result<(), ProtocolError> {
+        const N: usize = 4;
+        let participants = vec![
+            Participant::from(0u32),
+            Participant::from(1u32),
+            Participant::from(2u32),
+        ];
+
+        let prep: Vec<_> = participants
+            .iter()
+            .map(|p| {
+                let a_iv = (0..N)
+                    .map(|_| Scalar::generate_biased(&mut OsRng))
+                    .collect::<Vec<_>>();
+                let b_iv = (0..N)
+                    .map(|_| Scalar::generate_biased(&mut OsRng))
+                    .collect::<Vec<_>>();
+                (p, a_iv, b_iv)
+            })
+            .collect();
+
+        let a_v = prep
+            .iter()
+            .fold(vec![Scalar::ZERO; N], |acc, (_, a_iv, _)| {
+                acc.iter()
+                    .zip(a_iv.iter())
+                    .map(|(acc_i, a_i)| acc_i + a_i)
+                    .collect()
+            });
+        let b_v = prep
+            .iter()
+            .fold(vec![Scalar::ZERO; N], |acc, (_, _, b_iv)| {
+                acc.iter()
+                    .zip(b_iv.iter())
+                    .map(|(acc_i, b_i)| acc_i + b_i)
+                    .collect()
+            });
+
+        let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = Vec<Scalar>>>)> =
+            Vec::with_capacity(prep.len());
+
+        let sids: Vec<_> = (0..N).map(|i| hash(&format!("sid{}", i))).collect();
+
+        for (p, a_iv, b_iv) in prep {
+            let ctx = Context::new();
+            let prot = make_protocol(
+                ctx.clone(),
+                multiplication_many::<Secp256k1, N>(
+                    ctx,
+                    sids.clone(),
+                    ParticipantList::new(&participants).unwrap(),
+                    *p,
+                    a_iv,
+                    b_iv,
+                ),
+            );
+            protocols.push((*p, Box::new(prot)))
+        }
+
+        let result = run_protocol(protocols)?;
+        let c_v: Vec<_> = result
+            .into_iter()
+            .fold(vec![Scalar::ZERO; N], |acc, (_, c_iv)| {
+                acc.iter()
+                    .zip(c_iv.iter())
+                    .map(|(acc_i, c_i)| acc_i + c_i)
+                    .collect()
+            });
+
+        for i in 0..N {
+            assert_eq!(a_v[i] * b_v[i], c_v[i]);
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
* The previous implementation of multiplication_many does 4 * N (plus some constant) rounds of communication anyway, because there's a loop that has an await inside. Removed that implementation. Replaced it with just using multiple futures of multiplication computation, and joining them in parallel.
* For each pair of participants, the random oblivious transfer doesn't actually care which one is the sender and which is the receiver. The original specification picks a total order such that if p < me then we send otherwise we receive. But that's not necessary, and causes a big network bandwidth imbalance. We change this to pick hash(i, p) < hash(i, me) where i is the index in the batch. This gives a balanced network usage.
* Fix incorrect use of Context::run call (????), which causes stack overflow because it's calling the async runtime from an async future. Not sure why that's in there but it's completely unnecessary. Also join gamma0 and gamma1 properly.