### PR TITLE
Expose `make_protocol`, `Participants` module and other

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ required-features = ["k256"]
 
 [features]
 k256 = ["dep:k256"]
+## Expose internal types. This is an advanced feature which can be useful
+## if you need to build a modified version of protocol.
+internals = []
 
 [[example]]
 name = "network-benches"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,12 @@ mod constants;
 mod crypto;
 mod keyshare;
 mod math;
+
+#[cfg(feature = "internals")]
+pub mod participants;
+#[cfg(not(feature = "internals"))]
 mod participants;
+
 mod presign;
 mod proofs;
 pub mod protocol;

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -237,3 +237,10 @@ pub(crate) fn run_two_party_protocol<T0: fmt::Debug, T1: fmt::Debug>(
 }
 
 pub(crate) mod internal;
+
+#[cfg(feature = "internals")]
+pub use internal::make_protocol;
+#[cfg(feature = "internals")]
+pub use internal::Context;
+#[cfg(feature = "internals")]
+pub use internal::SharedChannel;


### PR DESCRIPTION
* `make_protocol` allows converting a future object into a `Protocol trait`
* `Context, SharedChannel` – internal primitives, which allow creating waiting points and do communication.
* `Participants` module exposes useful primitives such as `ParticipantCounter`

This PR operates in context of https://github.com/Near-One/mpc/issues/119