### PR TITLE
Scalar serialization bugfix

### DIFF
--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -1,7 +1,17 @@
 //! This module serves as a wrapper for Frost protocol.
+
 use frost_secp256k1::Secp256K1Sha256;
+use crate::generic_dkg::{BytesOrder, Ciphersuite, ScalarSerializationFormat};
 
 pub type KeygenOutput = crate::generic_dkg::KeygenOutput<Secp256K1Sha256>;
+
+impl ScalarSerializationFormat for Secp256K1Sha256 {
+    fn bytes_order() -> BytesOrder {
+        BytesOrder::BigEndian
+    }
+}
+
+impl Ciphersuite for Secp256K1Sha256 {}
 
 pub mod dkg_ecdsa;
 pub mod math;

--- a/src/ecdsa/test.rs
+++ b/src/ecdsa/test.rs
@@ -286,13 +286,14 @@ fn test_e2e() -> Result<(), Box<dyn Error>> {
 #[test]
 fn test_e2e_random_identifiers() -> Result<(), Box<dyn Error>> {
     let participants_count = 3;
-    let participants: Vec<_> = (0..participants_count)
+    let mut participants: Vec<_> = (0..participants_count)
         .map(|_| Participant::from(rand::random::<u32>()))
         .collect();
     let threshold = 3;
 
     let mut keygen_result = run_keygen(&participants.clone(), threshold)?;
     keygen_result.sort_by_key(|(p, _)| *p);
+    let participants = keygen_result.iter().map(|(p, _)| *p).collect::<Vec<_>>();
 
     let public_key = keygen_result[0].1.public_key_package.clone();
     assert_eq!(

--- a/src/ecdsa/test.rs
+++ b/src/ecdsa/test.rs
@@ -289,11 +289,11 @@ fn test_e2e_random_identifiers() -> Result<(), Box<dyn Error>> {
     let mut participants: Vec<_> = (0..participants_count)
         .map(|_| Participant::from(rand::random::<u32>()))
         .collect();
+    participants.sort();
     let threshold = 3;
 
     let mut keygen_result = run_keygen(&participants.clone(), threshold)?;
     keygen_result.sort_by_key(|(p, _)| *p);
-    let participants = keygen_result.iter().map(|(p, _)| *p).collect::<Vec<_>>();
 
     let public_key = keygen_result[0].1.public_key_package.clone();
     assert_eq!(

--- a/src/ecdsa/test.rs
+++ b/src/ecdsa/test.rs
@@ -282,3 +282,40 @@ fn test_e2e() -> Result<(), Box<dyn Error>> {
     );
     Ok(())
 }
+
+#[test]
+fn test_e2e_random_identifiers() -> Result<(), Box<dyn Error>> {
+    let participants_count = 3;
+    let participants: Vec<_> = (0..participants_count)
+        .map(|_| Participant::from(rand::random::<u32>()))
+        .collect();
+    let threshold = 3;
+
+    let mut keygen_result = run_keygen(&participants.clone(), threshold)?;
+    keygen_result.sort_by_key(|(p, _)| *p);
+
+    let public_key = keygen_result[0].1.public_key_package.clone();
+    assert_eq!(
+        keygen_result[0].1.public_key_package,
+        keygen_result[1].1.public_key_package
+    );
+    assert_eq!(
+        keygen_result[1].1.public_key_package,
+        keygen_result[2].1.public_key_package
+    );
+
+    let (pub0, shares0) = triples::deal(&mut OsRng, &participants, threshold);
+    let (pub1, shares1) = triples::deal(&mut OsRng, &participants, threshold);
+
+    let mut presign_result = run_presign(keygen_result, shares0, shares1, &pub0, &pub1, threshold);
+    presign_result.sort_by_key(|(p, _)| *p);
+
+    let msg = b"hello world";
+
+    run_sign(
+        presign_result,
+        public_key.verifying_key().to_element().to_affine(),
+        msg,
+    );
+    Ok(())
+}

--- a/src/eddsa/dkg_ed25519.rs
+++ b/src/eddsa/dkg_ed25519.rs
@@ -100,11 +100,12 @@ mod test {
 
     #[test]
     fn test_keygen() -> Result<(), Box<dyn Error>> {
-        let participants = vec![
+        let mut participants = vec![
             Participant::from(31u32),
             Participant::from(1u32),
             Participant::from(2u32),
         ];
+        participants.sort();
         let threshold = 3;
 
         let result = run_keygen(&participants, threshold)?;

--- a/src/eddsa/dkg_ed25519.rs
+++ b/src/eddsa/dkg_ed25519.rs
@@ -100,12 +100,11 @@ mod test {
 
     #[test]
     fn test_keygen() -> Result<(), Box<dyn Error>> {
-        let mut participants = vec![
+        let participants = vec![
             Participant::from(31u32),
             Participant::from(1u32),
             Participant::from(2u32),
         ];
-        participants.sort();
         let threshold = 3;
 
         let result = run_keygen(&participants, threshold)?;

--- a/src/eddsa/mod.rs
+++ b/src/eddsa/mod.rs
@@ -1,6 +1,16 @@
 //! This module serves as a wrapper for Frost protocol.
 use frost_ed25519::Ed25519Sha512;
+use crate::generic_dkg::{BytesOrder, Ciphersuite, ScalarSerializationFormat};
+
 pub type KeygenOutput = crate::generic_dkg::KeygenOutput<Ed25519Sha512>;
+
+impl ScalarSerializationFormat for Ed25519Sha512 {
+    fn bytes_order() -> BytesOrder {
+        BytesOrder::LittleEndian
+    }
+}
+
+impl Ciphersuite for Ed25519Sha512 {}
 
 pub mod dkg_ed25519;
 pub mod sign;

--- a/src/generic_dkg.rs
+++ b/src/generic_dkg.rs
@@ -9,12 +9,20 @@ use frost_core::keys::{
     CoefficientCommitment, PublicKeyPackage, SecretShare, SigningShare,
     VerifiableSecretSharingCommitment, VerifyingShare,
 };
-use frost_core::{
-    Challenge, Ciphersuite, Element, Error, Field, Group, Scalar, Signature, SigningKey,
-    VerifyingKey,
-};
+use frost_core::{Challenge, Element, Error, Field, Group, Scalar, Signature, SigningKey, VerifyingKey};
 use rand_core::OsRng;
 use std::ops::Index;
+
+pub enum BytesOrder {
+    BigEndian,
+    LittleEndian,
+}
+
+pub trait ScalarSerializationFormat {
+    fn bytes_order() -> BytesOrder;
+}
+
+pub trait Ciphersuite: frost_core::Ciphersuite + ScalarSerializationFormat {}
 
 const LABEL: &[u8] = b"Generic DKG";
 

--- a/src/participants.rs
+++ b/src/participants.rs
@@ -6,10 +6,11 @@
 
 use std::{collections::HashMap, mem, ops::Index};
 
-use frost_core::{Ciphersuite, Group, Scalar};
+use frost_core::{Group, Scalar};
 use serde::Serialize;
 
 use crate::{compat::CSCurve, protocol::Participant};
+use crate::generic_dkg::Ciphersuite;
 
 /// Represents a sorted list of participants.
 ///


### PR DESCRIPTION
### Overview

`curve_dalek25519::Scalar` and `k256::Scalar` use different serialization formats: Little Endian and Big Endian respectively. Thus, ecdsa implementation doesn't work correctly. 

This PR adds a test and a bugfix for it.

### Why tests were passing before?

All identifiers were under `u8`. Thus it was the only non-zero byte in the `[u8; 32]`. Even in this case, it shouldn't have worked correctly. Perhaps some heuristics or optimizations were in place.