### PR TITLE
Kuksag/dkg adjustments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ frost-ed25519 = "2.1.0"
 frost-secp256k1 = "2.1.0"
 futures = "0.3.31"
 itertools = "0.14.0"
-k256 = { version = "0.13.1", features = ["sha256", "ecdsa", "serde"], optional = true }
+k256 = { version = "0.13.1", features = ["sha256", "ecdsa", "serde"] }
 magikitten = "0.2.0"
 rand = "0.9.0"
 rand_core = { version = "0.6.4", features = ["getrandom"] }
@@ -34,10 +34,6 @@ haisou-chan = { git = "https://github.com/cronokirby/haisou-chan", rev = "d28c46
 structopt = "0.3.26"
 k256 = { version = "0.13.1", features = ["sha256", "ecdsa", "serde"], optional = false }
 
-[features]
-k256 = ["dep:k256"]
-
 [[example]]
 name = "network-benches"
 path = "examples/network-benches.rs"
-required-features = ["k256"]

--- a/examples/network-benches.rs
+++ b/examples/network-benches.rs
@@ -252,7 +252,7 @@ fn main() {
     );
     let start = Instant::now();
     let results = run_protocol(latency, bandwidth, &participants, |p| {
-        triples::generate_triple::<Secp256k1>(&participants, p, 3).unwrap()
+        triples::generate_triple::<Secp256k1>(&participants, p, args.parties as usize).unwrap()
     });
     let stop = Instant::now();
     println!("time:\t{:#?}", stop.duration_since(start));
@@ -266,7 +266,7 @@ fn main() {
     );
     let start = Instant::now();
     let results = run_protocol(latency, bandwidth, &participants, |p| {
-        keygen(&participants, p, 3).unwrap()
+        keygen(&participants, p, args.parties as usize).unwrap()
     });
     let stop = Instant::now();
     println!("time:\t{:#?}", stop.duration_since(start));
@@ -275,7 +275,7 @@ fn main() {
     let shares: HashMap<_, _> = results.into_iter().map(|(p, _, out)| (p, out)).collect();
 
     let (other_triples_pub, other_triples_share) =
-        triples::deal(&mut OsRng, &participants, 3);
+        triples::deal(&mut OsRng, &participants, args.parties as usize);
     let other_triples: HashMap<_, _> = participants
         .iter()
         .zip(other_triples_share)
@@ -297,7 +297,7 @@ fn main() {
                 triple0: triples[&p].clone(),
                 triple1: other_triples[&p].clone(),
                 keygen_out: shares[&p].clone(),
-                threshold: 3,
+                threshold: args.parties as usize,
             },
         )
         .unwrap()

--- a/src/compat/mod.rs
+++ b/src/compat/mod.rs
@@ -41,7 +41,6 @@ pub trait CSCurve: PrimeCurve + CurveArithmetic {
     fn sample_scalar_constant_time<R: CryptoRngCore>(r: &mut R) -> Self::Scalar;
 }
 
-#[cfg(any(feature = "k256", test))]
 mod k256_impl {
     use super::*;
 

--- a/src/ecdsa/dkg_ecdsa.rs
+++ b/src/ecdsa/dkg_ecdsa.rs
@@ -1,4 +1,5 @@
 use frost_secp256k1::*;
+use frost_secp256k1::keys::SigningShare;
 use futures::FutureExt;
 use k256::Secp256k1;
 use crate::ecdsa::KeygenOutput;
@@ -25,7 +26,7 @@ pub fn keygen(
 pub fn reshare(
     old_participants: &[Participant],
     old_threshold: usize,
-    old_signing_key: Option<SigningKey>,
+    old_signing_key: Option<SigningShare>,
     old_public_key: VerifyingKey,
     new_participants: &[Participant],
     new_threshold: usize,
@@ -56,7 +57,7 @@ pub fn reshare(
 
 /// Performs the Ed25519 Refresh protocol
 pub fn refresh(
-    old_signing_key: Option<SigningKey>,
+    old_signing_key: Option<SigningShare>,
     old_public_key: VerifyingKey,
     new_participants: &[Participant],
     new_threshold: usize,

--- a/src/ecdsa/dkg_ecdsa.rs
+++ b/src/ecdsa/dkg_ecdsa.rs
@@ -1,6 +1,6 @@
 use frost_secp256k1::*;
-use keys::PublicKeyPackage;
-
+use futures::FutureExt;
+use k256::Secp256k1;
 use crate::ecdsa::KeygenOutput;
 use crate::generic_dkg::*;
 use crate::protocol::internal::{make_protocol, Context};
@@ -13,10 +13,11 @@ pub fn keygen(
     participants: &[Participant],
     me: Participant,
     threshold: usize,
-) -> Result<impl Protocol<Output = KeygenOutput>, InitializationError> {
+) -> Result<impl Protocol<Output = KeygenOutput<Secp256k1>>, InitializationError> {
     let ctx = Context::new();
     let participants = assert_keygen_invariants(participants, me, threshold)?;
-    let fut = do_keygen(ctx.shared_channel(), participants, me, threshold);
+    let fut = do_keygen::<Secp256K1Sha256>(ctx.shared_channel(), participants, me, threshold)
+        .map(|x| x.map(Into::into));
     Ok(make_protocol(ctx, fut))
 }
 
@@ -25,14 +26,13 @@ pub fn reshare(
     old_participants: &[Participant],
     old_threshold: usize,
     old_signing_key: Option<SigningKey>,
-    old_public_key: PublicKeyPackage,
+    old_public_key: VerifyingKey,
     new_participants: &[Participant],
     new_threshold: usize,
     me: Participant,
-) -> Result<impl Protocol<Output = KeygenOutput>, InitializationError> {
+) -> Result<impl Protocol<Output = KeygenOutput<Secp256k1>>, InitializationError> {
     let ctx = Context::new();
     let threshold = new_threshold;
-    let old_public_key = *old_public_key.verifying_key();
     let (participants, old_participants) = reshare_assertions::<E>(
         new_participants,
         me,
@@ -49,18 +49,19 @@ pub fn reshare(
         old_signing_key,
         old_public_key,
         old_participants,
-    );
+    )
+        .map(|x| x.map(Into::into));
     Ok(make_protocol(ctx, fut))
 }
 
 /// Performs the Ed25519 Refresh protocol
 pub fn refresh(
     old_signing_key: Option<SigningKey>,
-    old_public_key: PublicKeyPackage,
+    old_public_key: VerifyingKey,
     new_participants: &[Participant],
     new_threshold: usize,
     me: Participant,
-) -> Result<impl Protocol<Output = KeygenOutput>, InitializationError> {
+) -> Result<impl Protocol<Output = KeygenOutput<Secp256k1>>, InitializationError> {
     if old_signing_key.is_none() {
         return Err(InitializationError::BadParameters(format!(
             "The participant {me:?} is running refresh without an old share",
@@ -68,7 +69,6 @@ pub fn refresh(
     }
     let ctx = Context::new();
     let threshold = new_threshold;
-    let old_public_key = *old_public_key.verifying_key();
     let (participants, old_participants) = reshare_assertions::<E>(
         new_participants,
         me,
@@ -85,7 +85,8 @@ pub fn refresh(
         old_signing_key,
         old_public_key,
         old_participants,
-    );
+    )
+        .map(|x| x.map(Into::into));
     Ok(make_protocol(ctx, fut))
 }
 
@@ -112,21 +113,21 @@ mod test {
 
         assert!(result.len() == participants.len());
         assert_eq!(
-            result[0].1.public_key_package,
-            result[1].1.public_key_package
+            result[0].1.public_key,
+            result[1].1.public_key
         );
         assert_eq!(
-            result[1].1.public_key_package,
-            result[2].1.public_key_package
+            result[1].1.public_key,
+            result[2].1.public_key
         );
 
-        let pub_key = result[2].1.public_key_package.verifying_key().to_element();
+        let pub_key = result[2].1.public_key;
 
         let participants = vec![result[0].0, result[1].0, result[2].0];
         let shares = vec![
-            result[0].1.private_share.to_scalar(),
-            result[1].1.private_share.to_scalar(),
-            result[2].1.private_share.to_scalar(),
+            result[0].1.private_share,
+            result[1].1.private_share,
+            result[2].1.private_share,
         ];
         let p_list = ParticipantList::new(&participants).unwrap();
         let x = p_list.generic_lagrange::<E>(participants[0]) * shares[0]
@@ -148,16 +149,16 @@ mod test {
         let result0 = run_keygen(&participants, threshold)?;
         assert_public_key_invariant(&result0)?;
 
-        let pub_key = result0[2].1.public_key_package.verifying_key().to_element();
+        let pub_key = result0[2].1.public_key;
 
         let result1 = run_refresh(&participants, result0, threshold)?;
         assert_public_key_invariant(&result1)?;
 
         let participants = vec![result1[0].0, result1[1].0, result1[2].0];
         let shares = vec![
-            result1[0].1.private_share.to_scalar(),
-            result1[1].1.private_share.to_scalar(),
-            result1[2].1.private_share.to_scalar(),
+            result1[0].1.private_share,
+            result1[1].1.private_share,
+            result1[2].1.private_share,
         ];
         let p_list = ParticipantList::new(&participants).unwrap();
         let x = p_list.generic_lagrange::<E>(participants[0]) * shares[0]
@@ -180,7 +181,7 @@ mod test {
         let result0 = run_keygen(&participants, threshold0)?;
         assert_public_key_invariant(&result0)?;
 
-        let pub_key = result0[2].1.public_key_package.clone();
+        let pub_key = result0[2].1.public_key;
 
         let mut new_participant = participants.clone();
         new_participant.push(Participant::from(31u32));
@@ -196,10 +197,10 @@ mod test {
 
         let participants = vec![result1[0].0, result1[1].0, result1[2].0, result1[3].0];
         let shares = vec![
-            result1[0].1.private_share.to_scalar(),
-            result1[1].1.private_share.to_scalar(),
-            result1[2].1.private_share.to_scalar(),
-            result1[3].1.private_share.to_scalar(),
+            result1[0].1.private_share,
+            result1[1].1.private_share,
+            result1[2].1.private_share,
+            result1[3].1.private_share,
         ];
         let p_list = ParticipantList::new(&participants).unwrap();
         let x = p_list.generic_lagrange::<E>(participants[0]) * shares[0]
@@ -208,7 +209,7 @@ mod test {
             + p_list.generic_lagrange::<E>(participants[3]) * shares[3];
         assert_eq!(
             <Secp256K1Group>::generator() * x,
-            pub_key.verifying_key().to_element()
+            pub_key
         );
 
         Ok(())

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -2,8 +2,26 @@
 
 use frost_secp256k1::Secp256K1Sha256;
 use crate::generic_dkg::{BytesOrder, Ciphersuite, ScalarSerializationFormat};
+use elliptic_curve::CurveArithmetic;
+use frost_secp256k1::*;
+use k256::Secp256k1;
+use serde::{Deserialize, Serialize};
+use crate::CSCurve;
 
-pub type KeygenOutput = crate::generic_dkg::KeygenOutput<Secp256K1Sha256>;
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeygenOutput<C: CSCurve> {
+    pub private_share: C::Scalar,
+    pub public_key: C::AffinePoint,
+}
+
+impl From<crate::generic_dkg::KeygenOutput<Secp256K1Sha256>> for KeygenOutput<Secp256k1> {
+    fn from(value: crate::generic_dkg::KeygenOutput<Secp256K1Sha256>) -> Self {
+        Self {
+            private_share: value.private_share.to_scalar(),
+            public_key: value.public_key_package.verifying_key().to_element().into(),
+        }
+    }
+}
 
 impl ScalarSerializationFormat for Secp256K1Sha256 {
     fn bytes_order() -> BytesOrder {

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -2,7 +2,6 @@
 
 use frost_secp256k1::Secp256K1Sha256;
 use crate::generic_dkg::{BytesOrder, Ciphersuite, ScalarSerializationFormat};
-use elliptic_curve::CurveArithmetic;
 use frost_secp256k1::*;
 use k256::Secp256k1;
 use serde::{Deserialize, Serialize};

--- a/src/ecdsa/presign.rs
+++ b/src/ecdsa/presign.rs
@@ -1,5 +1,5 @@
 use elliptic_curve::{Field, Group, ScalarPrimitive};
-
+use elliptic_curve::group::prime::PrimeCurveAffine;
 use crate::compat::CSCurve;
 use crate::ecdsa::triples::{TriplePub, TripleShare};
 use crate::ecdsa::KeygenOutput;
@@ -35,34 +35,9 @@ pub struct PresignArguments<C: CSCurve> {
     /// Ditto, for the second triple.
     pub triple1: (TripleShare<C>, TriplePub<C>),
     /// The output of key generation, i.e. our share of the secret key, and the public key package.
-    /// This is of type KeygenOutput<Secp256K1Sha256> from Frost implementation
-    pub keygen_out: KeygenOutput,
+    pub keygen_out: KeygenOutput<C>,
     /// The desired threshold for the presignature, which must match the original threshold
     pub threshold: usize,
-}
-
-/// Transforms a verification key of type Secp256k1SHA256 to CSCurve of cait-sith
-fn from_secp256k1sha256_to_cscurve_vk<C: CSCurve>(
-    verifying_key: &VerifyingKey,
-) -> Result<C::ProjectivePoint, ProtocolError> {
-    // serializes into a canonical byte array buf of length 33 bytes using the  affine point representation
-    let bytes = verifying_key
-        .serialize()
-        .map_err(|_| ProtocolError::PointSerialization)?;
-
-    let bytes: [u8; 33] = bytes.try_into().expect("Slice is not 33 bytes long");
-    let point = match C::from_bytes_to_affine(bytes) {
-        Some(point) => point,
-        _ => return Err(ProtocolError::PointSerialization),
-    };
-    Ok(point)
-}
-
-/// Transforms a secret key of type Secp256k1Sha256 to CSCurve of cait-sith
-fn from_secp256k1sha256_to_cscurve_sk<C: CSCurve>(private_share: &SigningKey) -> C::Scalar {
-    let bytes = private_share.serialize();
-    let bytes: [u8; 32] = bytes.try_into().expect("Slice is not 32 bytes long");
-    C::from_bytes_to_scalar(bytes).unwrap()
 }
 
 async fn do_presign<C: CSCurve>(
@@ -95,11 +70,8 @@ async fn do_presign<C: CSCurve>(
     let a_prime_i = bt_lambda * a_i;
     let b_prime_i = bt_lambda * b_i;
 
-    let public_key = from_secp256k1sha256_to_cscurve_vk::<C>(
-        args.keygen_out.public_key_package.verifying_key(),
-    )?;
-    let big_x: C::ProjectivePoint = public_key;
-    let private_share = from_secp256k1sha256_to_cscurve_sk::<C>(&args.keygen_out.private_share);
+    let big_x: C::ProjectivePoint = args.keygen_out.public_key.into();
+    let private_share = args.keygen_out.private_share;
     let x_prime_i = sk_lambda * private_share;
 
     // Spec 1.4
@@ -292,11 +264,9 @@ mod test {
         {
             let private_share = f.evaluate(&p.scalar::<Secp256k1>());
             let dummy_tree: BTreeMap<Identifier, VerifyingShare> = BTreeMap::new();
-            let verifying_key = VerifyingKey::new(big_x);
-            let public_key_package = PublicKeyPackage::new(dummy_tree, verifying_key);
             let keygen_out = KeygenOutput {
-                private_share: SigningKey::from_scalar(private_share).unwrap(),
-                public_key_package,
+                private_share,
+                public_key: big_x.into(),
             };
 
             let protocol = presign(

--- a/src/ecdsa/presign.rs
+++ b/src/ecdsa/presign.rs
@@ -1,5 +1,4 @@
 use elliptic_curve::{Field, Group, ScalarPrimitive};
-use elliptic_curve::group::prime::PrimeCurveAffine;
 use crate::compat::CSCurve;
 use crate::ecdsa::triples::{TriplePub, TripleShare};
 use crate::ecdsa::KeygenOutput;
@@ -10,7 +9,6 @@ use crate::{
     participants::ParticipantList,
     protocol::{Participant, ProtocolError},
 };
-use frost_secp256k1::{SigningKey, VerifyingKey};
 use serde::{Deserialize, Serialize};
 
 /// The output of the presigning protocol.

--- a/src/ecdsa/presign.rs
+++ b/src/ecdsa/presign.rs
@@ -1,4 +1,3 @@
-use elliptic_curve::{Field, Group, ScalarPrimitive};
 use crate::compat::CSCurve;
 use crate::ecdsa::triples::{TriplePub, TripleShare};
 use crate::ecdsa::KeygenOutput;
@@ -9,6 +8,7 @@ use crate::{
     participants::ParticipantList,
     protocol::{Participant, ProtocolError},
 };
+use elliptic_curve::{Field, Group, ScalarPrimitive};
 use serde::{Deserialize, Serialize};
 
 /// The output of the presigning protocol.
@@ -223,7 +223,7 @@ mod test {
     use rand_core::OsRng;
 
     use crate::{ecdsa::math::Polynomial, ecdsa::triples, protocol::run_protocol};
-    use frost_secp256k1::keys::{PublicKeyPackage, VerifyingShare};
+    use frost_secp256k1::keys::VerifyingShare;
     use frost_secp256k1::Identifier;
     use std::collections::BTreeMap;
 

--- a/src/ecdsa/sign.rs
+++ b/src/ecdsa/sign.rs
@@ -270,7 +270,7 @@ mod test {
         let result0 = run_keygen(&participants, threshold)?;
         assert_public_key_invariant(&result0)?;
 
-        let pub_key = result0[2].1.public_key_package.clone();
+        let pub_key = result0[2].1.public_key;
 
         // Run heavy reshare
         let new_threshold = 5;
@@ -289,7 +289,7 @@ mod test {
         assert_public_key_invariant(&key_packages)?;
         key_packages.sort_by_key(|(p, _)| *p);
 
-        let public_key = key_packages[0].1.public_key_package.clone();
+        let public_key = key_packages[0].1.public_key;
         // Prepare triples
         let (pub0, shares0) = deal(&mut OsRng, &new_participant, new_threshold);
         let (pub1, shares1) = deal(&mut OsRng, &new_participant, new_threshold);
@@ -303,7 +303,7 @@ mod test {
 
         run_sign(
             presign_result,
-            public_key.verifying_key().to_element().to_affine(),
+            public_key,
             msg,
         );
         Ok(())
@@ -322,7 +322,7 @@ mod test {
         let result0 = run_keygen(&participants, threshold)?;
         assert_public_key_invariant(&result0)?;
 
-        let pub_key = result0[2].1.public_key_package.clone();
+        let pub_key = result0[2].1.public_key;
 
         // Run heavy reshare
         let new_threshold = 3;
@@ -339,7 +339,7 @@ mod test {
         assert_public_key_invariant(&key_packages)?;
         key_packages.sort_by_key(|(p, _)| *p);
 
-        let public_key = key_packages[0].1.public_key_package.clone();
+        let public_key = key_packages[0].1.public_key;
         // Prepare triples
         let (pub0, shares0) = deal(&mut OsRng, &new_participant, new_threshold);
         let (pub1, shares1) = deal(&mut OsRng, &new_participant, new_threshold);
@@ -353,7 +353,7 @@ mod test {
 
         run_sign(
             presign_result,
-            public_key.verifying_key().to_element().to_affine(),
+            public_key,
             msg,
         );
         Ok(())

--- a/src/ecdsa/test.rs
+++ b/src/ecdsa/test.rs
@@ -294,6 +294,7 @@ fn test_e2e_random_identifiers() -> Result<(), Box<dyn Error>> {
 
     let mut keygen_result = run_keygen(&participants.clone(), threshold)?;
     keygen_result.sort_by_key(|(p, _)| *p);
+    let participants = keygen_result.iter().map(|(p, _)| *p).collect::<Vec<_>>();
 
     let public_key = keygen_result[0].1.public_key_package.clone();
     assert_eq!(

--- a/src/ecdsa/test.rs
+++ b/src/ecdsa/test.rs
@@ -1,6 +1,6 @@
-use k256::{AffinePoint, Secp256k1};
+use k256::{AffinePoint, Scalar, Secp256k1};
 use std::error::Error;
-
+use frost_core::VerifyingKey;
 use crate::compat::scalar_hash;
 
 use crate::ecdsa::dkg_ecdsa::{keygen, refresh, reshare};
@@ -13,15 +13,15 @@ use crate::ecdsa::{
 use crate::protocol::{run_protocol, Participant, Protocol};
 
 use frost_secp256k1::keys::{PublicKeyPackage, VerifyingShare};
-use frost_secp256k1::Group;
+use frost_secp256k1::{Group, SigningKey};
 use rand_core::OsRng;
 
 /// runs distributed keygen
 pub(crate) fn run_keygen(
     participants: &[Participant],
     threshold: usize,
-) -> Result<Vec<(Participant, KeygenOutput)>, Box<dyn Error>> {
-    let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = KeygenOutput>>)> =
+) -> Result<Vec<(Participant, KeygenOutput<Secp256k1>)>, Box<dyn Error>> {
+    let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = KeygenOutput<Secp256k1>>>)> =
         Vec::with_capacity(participants.len());
 
     for p in participants.iter() {
@@ -36,16 +36,16 @@ pub(crate) fn run_keygen(
 /// runs distributed refresh
 pub(crate) fn run_refresh(
     participants: &[Participant],
-    keys: Vec<(Participant, KeygenOutput)>,
+    keys: Vec<(Participant, KeygenOutput<Secp256k1>)>,
     threshold: usize,
-) -> Result<Vec<(Participant, KeygenOutput)>, Box<dyn Error>> {
-    let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = KeygenOutput>>)> =
+) -> Result<Vec<(Participant, KeygenOutput<Secp256k1>)>, Box<dyn Error>> {
+    let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = KeygenOutput<Secp256k1>>>)> =
         Vec::with_capacity(participants.len());
 
     for (p, out) in keys.iter() {
         let protocol = refresh(
-            Some(out.private_share),
-            out.public_key_package.clone(),
+            Some(SigningKey::from_scalar(out.private_share)?),
+            VerifyingKey::new(out.public_key.into()),
             &participants,
             threshold,
             *p,
@@ -60,12 +60,12 @@ pub(crate) fn run_refresh(
 /// runs distributed reshare
 pub(crate) fn run_reshare(
     participants: &[Participant],
-    pub_key: &PublicKeyPackage,
-    keys: Vec<(Participant, KeygenOutput)>,
+    pub_key: &AffinePoint,
+    keys: Vec<(Participant, KeygenOutput<Secp256k1>)>,
     old_threshold: usize,
     new_threshold: usize,
     new_participants: Vec<Participant>,
-) -> Result<Vec<(Participant, KeygenOutput)>, Box<dyn Error>> {
+) -> Result<Vec<(Participant, KeygenOutput<Secp256k1>)>, Box<dyn Error>> {
     assert!(new_participants.len() > 0);
     let mut setup: Vec<_> = vec![];
 
@@ -75,26 +75,30 @@ pub(crate) fn run_reshare(
             if p.clone() == new_participant.clone() {
                 setup.push((
                     p.clone(),
-                    (Some(k.private_share.clone()), k.public_key_package.clone()),
+                    (Some(k.private_share.clone()), k.public_key),
                 ));
                 is_break = true;
                 break;
             }
         }
         if !is_break {
-            setup.push((new_participant.clone(), (None, pub_key.clone())));
+            setup.push((new_participant.clone(), (None, *pub_key)));
         }
     }
 
-    let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = KeygenOutput>>)> =
+    let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = KeygenOutput<Secp256k1>>>)> =
         Vec::with_capacity(participants.len());
 
     for (p, out) in setup.iter() {
+        let old_share = match out.0 {
+            None => None,
+            Some(scalar) => Some(SigningKey::from_scalar(scalar)?)
+        };
         let protocol = reshare(
             &participants,
             old_threshold,
-            out.0,
-            out.1.clone(),
+            old_share,
+            VerifyingKey::new(out.1.clone().into()),
             &new_participants,
             new_threshold,
             *p,
@@ -107,19 +111,15 @@ pub(crate) fn run_reshare(
 }
 
 /// Assert that:
-///     1. Each participant has the same view of `PublicKeyPackage`
-///     2. Each participant is present in `PublicKeyPackage::verifying_shares()`
-///     3. No "other" participant is present in `PublicKeyPackage::verifying_shares()`
-///     4. For each participant their `verifying_share = secret_share * G`
-///     5. For each participant their `verifying_share` is the same across `KeyPackage` and `PublicKeyPackage`
+///     * For each participant their `verifying_share` is the same across `KeyPackage` and `PublicKeyPackage`
 pub(crate) fn assert_public_key_invariant(
-    participants: &[(Participant, KeygenOutput)],
+    participants: &[(Participant, KeygenOutput<Secp256k1>)],
 ) -> Result<(), Box<dyn Error>> {
-    let public_key_package = participants.first().unwrap().1.public_key_package.clone();
+    let public_key_package = participants.first().unwrap().1.public_key;
 
     if participants
         .iter()
-        .any(|(_, key_pair)| key_pair.public_key_package != public_key_package)
+        .any(|(_, key_pair)| key_pair.public_key != public_key_package)
     {
         assert!(
             false,
@@ -127,53 +127,11 @@ pub(crate) fn assert_public_key_invariant(
         );
     }
 
-    if public_key_package.verifying_shares().len() != participants.len() {
-        assert!(
-            false,
-            "public key package has different number of verifying shares than participants"
-        );
-    }
-
-    for (participant, key_pair) in participants {
-        let scalar = key_pair.private_share.to_scalar();
-        let actual_verifying_share = {
-            let point = frost_secp256k1::Secp256K1Group::generator() * scalar;
-            VerifyingShare::new(point)
-        };
-
-        let verifying_share = key_pair
-            .public_key_package
-            .verifying_shares()
-            .get(&participant.to_identifier())
-            .unwrap()
-            .clone();
-        if actual_verifying_share != verifying_share {
-            assert!(
-                false,
-                "verifying share in `KeyPackage` is not equal to secret share * G"
-            );
-        }
-
-        {
-            let expected_verifying_share = key_pair
-                .public_key_package
-                .verifying_shares()
-                .get(&participant.to_identifier())
-                .unwrap();
-            if actual_verifying_share != *expected_verifying_share {
-                assert!(
-                    false,
-                    "verifying share in `PublicKeyPackage` is not equal to secret share * G"
-                );
-            }
-        }
-    }
-
     Ok(())
 }
 
 pub fn run_presign(
-    participants: Vec<(Participant, KeygenOutput)>,
+    participants: Vec<(Participant, KeygenOutput<Secp256k1>)>,
     shares0: Vec<TripleShare<Secp256k1>>,
     shares1: Vec<TripleShare<Secp256k1>>,
     pub0: &TriplePub<Secp256k1>,
@@ -257,14 +215,14 @@ fn test_e2e() -> Result<(), Box<dyn Error>> {
     let mut keygen_result = run_keygen(&participants.clone(), threshold)?;
     keygen_result.sort_by_key(|(p, _)| *p);
 
-    let public_key = keygen_result[0].1.public_key_package.clone();
+    let public_key = keygen_result[0].1.public_key;
     assert_eq!(
-        keygen_result[0].1.public_key_package,
-        keygen_result[1].1.public_key_package
+        keygen_result[0].1.public_key,
+        keygen_result[1].1.public_key
     );
     assert_eq!(
-        keygen_result[1].1.public_key_package,
-        keygen_result[2].1.public_key_package
+        keygen_result[1].1.public_key,
+        keygen_result[2].1.public_key
     );
 
     let (pub0, shares0) = triples::deal(&mut OsRng, &participants, threshold);
@@ -277,7 +235,7 @@ fn test_e2e() -> Result<(), Box<dyn Error>> {
 
     run_sign(
         presign_result,
-        public_key.verifying_key().to_element().to_affine(),
+        public_key,
         msg,
     );
     Ok(())
@@ -295,14 +253,14 @@ fn test_e2e_random_identifiers() -> Result<(), Box<dyn Error>> {
     let mut keygen_result = run_keygen(&participants.clone(), threshold)?;
     keygen_result.sort_by_key(|(p, _)| *p);
 
-    let public_key = keygen_result[0].1.public_key_package.clone();
+    let public_key = keygen_result[0].1.public_key;
     assert_eq!(
-        keygen_result[0].1.public_key_package,
-        keygen_result[1].1.public_key_package
+        keygen_result[0].1.public_key,
+        keygen_result[1].1.public_key
     );
     assert_eq!(
-        keygen_result[1].1.public_key_package,
-        keygen_result[2].1.public_key_package
+        keygen_result[1].1.public_key,
+        keygen_result[2].1.public_key
     );
 
     let (pub0, shares0) = triples::deal(&mut OsRng, &participants, threshold);
@@ -315,7 +273,7 @@ fn test_e2e_random_identifiers() -> Result<(), Box<dyn Error>> {
 
     run_sign(
         presign_result,
-        public_key.verifying_key().to_element().to_affine(),
+        public_key,
         msg,
     );
     Ok(())

--- a/src/ecdsa/test.rs
+++ b/src/ecdsa/test.rs
@@ -294,7 +294,6 @@ fn test_e2e_random_identifiers() -> Result<(), Box<dyn Error>> {
 
     let mut keygen_result = run_keygen(&participants.clone(), threshold)?;
     keygen_result.sort_by_key(|(p, _)| *p);
-    let participants = keygen_result.iter().map(|(p, _)| *p).collect::<Vec<_>>();
 
     let public_key = keygen_result[0].1.public_key_package.clone();
     assert_eq!(

--- a/src/eddsa/dkg_ed25519.rs
+++ b/src/eddsa/dkg_ed25519.rs
@@ -100,11 +100,12 @@ mod test {
 
     #[test]
     fn test_keygen() -> Result<(), Box<dyn Error>> {
-        let participants = vec![
+        let mut participants = vec![
             Participant::from(31u32),
             Participant::from(1u32),
             Participant::from(2u32),
         ];
+        participants.sort();
         let threshold = 3;
 
         let result = run_keygen(&participants, threshold)?;

--- a/src/eddsa/dkg_ed25519.rs
+++ b/src/eddsa/dkg_ed25519.rs
@@ -1,5 +1,6 @@
 use frost_ed25519::*;
 use frost_ed25519::keys::SigningShare;
+use futures::FutureExt;
 use keys::PublicKeyPackage;
 
 use crate::eddsa::KeygenOutput;
@@ -17,7 +18,8 @@ pub fn keygen(
 ) -> Result<impl Protocol<Output = KeygenOutput>, InitializationError> {
     let ctx = Context::new();
     let participants = assert_keygen_invariants(participants, me, threshold)?;
-    let fut = do_keygen(ctx.shared_channel(), participants, me, threshold);
+    let fut = do_keygen(ctx.shared_channel(), participants, me, threshold)
+        .map(|x| x.map(Into::into));
     Ok(make_protocol(ctx, fut))
 }
 
@@ -50,7 +52,8 @@ pub fn reshare(
         old_signing_key,
         old_public_key,
         old_participants,
-    );
+    )
+        .map(|x| x.map(Into::into));
     Ok(make_protocol(ctx, fut))
 }
 
@@ -86,7 +89,8 @@ pub fn refresh(
         old_signing_key,
         old_public_key,
         old_participants,
-    );
+    )
+        .map(|x| x.map(Into::into));
     Ok(make_protocol(ctx, fut))
 }
 

--- a/src/eddsa/dkg_ed25519.rs
+++ b/src/eddsa/dkg_ed25519.rs
@@ -100,12 +100,11 @@ mod test {
 
     #[test]
     fn test_keygen() -> Result<(), Box<dyn Error>> {
-        let mut participants = vec![
+        let participants = vec![
             Participant::from(31u32),
             Participant::from(1u32),
             Participant::from(2u32),
         ];
-        participants.sort();
         let threshold = 3;
 
         let result = run_keygen(&participants, threshold)?;

--- a/src/eddsa/dkg_ed25519.rs
+++ b/src/eddsa/dkg_ed25519.rs
@@ -1,4 +1,5 @@
 use frost_ed25519::*;
+use frost_ed25519::keys::SigningShare;
 use keys::PublicKeyPackage;
 
 use crate::eddsa::KeygenOutput;
@@ -24,7 +25,7 @@ pub fn keygen(
 pub fn reshare(
     old_participants: &[Participant],
     old_threshold: usize,
-    old_signing_key: Option<SigningKey>,
+    old_signing_key: Option<SigningShare>,
     old_public_key: PublicKeyPackage,
     new_participants: &[Participant],
     new_threshold: usize,
@@ -55,7 +56,7 @@ pub fn reshare(
 
 /// Performs the Ed25519 Refresh protocol
 pub fn refresh(
-    old_signing_key: Option<SigningKey>,
+    old_signing_key: Option<SigningShare>,
     old_public_key: PublicKeyPackage,
     new_participants: &[Participant],
     new_threshold: usize,

--- a/src/eddsa/kdf.rs
+++ b/src/eddsa/kdf.rs
@@ -3,99 +3,44 @@
 //! The general idea is that we have a `tweak` – some value, e.g. associated with a user.
 //! This value can be translated into Field scalar.
 //! Then the mapping functions are following:
-//! ```
+//!
 //! secret_key' = kdf(secret_key, tweak) = secret_key + tweak
 //! public_key' = kdf(public_key) = public_key + G * tweak
-//! ```
+//!
 //! Where G – group generator.
 //!
 //! Both for `KeyPackage` and `PublicKeyPackage` struct consist of some kind of helper objects
 //! like "verifying shares"/"verifying keys" etc. We have to do derivation for them and construct new objects.
-use crate::eddsa;
-use curve25519_dalek::Scalar;
-use crate::KeygenOutput;
-use frost_ed25519::keys::{KeyPackage, PublicKeyPackage, SigningShare, VerifyingShare};
-use frost_ed25519::{Ed25519Group, Group, Identifier, VerifyingKey};
+use crate::eddsa::KeygenOutput;
+use frost_core::Field;
+use frost_ed25519::keys::{PublicKeyPackage, SigningShare, VerifyingShare};
+use frost_ed25519::{Ed25519Group, Ed25519ScalarField, Group, Identifier, VerifyingKey};
 use std::collections::BTreeMap;
 
-pub(crate) fn derive_keygen_output(keygen_output: &KeygenOutput, tweak: [u8; 32]) -> KeygenOutput {
-    let tweak = Scalar::from_bytes_mod_order(tweak);
+pub fn derive_keygen_output(keygen_output: &KeygenOutput, tweak: [u8; 32]) -> KeygenOutput {
+    let tweak = <Ed25519ScalarField as Field>::Scalar::from_bytes_mod_order(tweak);
     KeygenOutput {
-        key_package: derive_key_package(&keygen_output.key_package, tweak),
+        private_share: SigningShare::new(keygen_output.private_share.to_scalar() + tweak),
         public_key_package: derive_public_key_package(&keygen_output.public_key_package, tweak),
     }
 }
 
-fn derive_public_key_package(pubkey_package: &PublicKeyPackage, tweak: Scalar) -> PublicKeyPackage {
+fn derive_public_key_package(
+    pubkey_package: &PublicKeyPackage,
+    tweak: <Ed25519ScalarField as Field>::Scalar,
+) -> PublicKeyPackage {
     let verifying_shares: BTreeMap<Identifier, VerifyingShare> = pubkey_package
         .verifying_shares()
         .iter()
         .map(|(&identifier, &share)| {
             (
                 identifier,
-                VerifyingShare::new(add_tweak(share.to_element(), tweak)),
+                VerifyingShare::new(share.to_element() + Ed25519Group::generator() * tweak),
             )
         })
         .collect();
-    let verifying_key = VerifyingKey::new(add_tweak(
-        pubkey_package.verifying_key().to_element(),
-        tweak,
-    ));
+    let verifying_key = VerifyingKey::new(
+        pubkey_package.verifying_key().to_element() + Ed25519Group::generator() * tweak,
+    );
     PublicKeyPackage::new(verifying_shares, verifying_key)
-}
-
-fn derive_key_package(key_package: &KeyPackage, tweak: Scalar) -> KeyPackage {
-    KeyPackage::new(
-        *key_package.identifier(),
-        SigningShare::new(key_package.signing_share().to_scalar() + tweak),
-        VerifyingShare::new(add_tweak(key_package.verifying_share().to_element(), tweak)),
-        VerifyingKey::new(add_tweak(key_package.verifying_key().to_element(), tweak)),
-        *key_package.min_signers(),
-    )
-}
-
-fn add_tweak(
-    point: curve25519_dalek::EdwardsPoint,
-    tweak: Scalar,
-) -> curve25519_dalek::EdwardsPoint {
-    point + Ed25519Group::generator() * tweak
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::frost::kdf::derive_keygen_output;
-    use crate::frost::tests::{build_key_packages_with_dealer, reconstruct_signing_key};
-    use aes_gcm::aead::rand_core::RngCore;
-    use rand::rngs::OsRng;
-
-    #[test]
-    fn proof_of_concept() -> Result<(), anyhow::Error> {
-        let max_signers = 9;
-        let min_signers = 6;
-
-        let mut tweak = [0u8; 32];
-        OsRng.fill_bytes(&mut tweak);
-
-        let participants = build_key_packages_with_dealer(max_signers, min_signers)
-            .into_iter()
-            .map(|(participant, key_pair)| (participant, derive_keygen_output(&key_pair, tweak)))
-            .collect::<Vec<_>>();
-
-        let verifying_key = *participants
-            .first()
-            .unwrap()
-            .1
-            .public_key_package
-            .verifying_key();
-
-        let signing_key = reconstruct_signing_key(participants.as_slice())?;
-
-        let mut message = [0u8; 32];
-        OsRng.fill_bytes(&mut message);
-
-        let signature = signing_key.sign(OsRng, message.as_slice());
-        verifying_key.verify(message.as_slice(), &signature)?;
-
-        Ok(())
-    }
 }

--- a/src/eddsa/mod.rs
+++ b/src/eddsa/mod.rs
@@ -16,3 +16,8 @@ pub mod dkg_ed25519;
 pub mod sign;
 #[cfg(test)]
 mod test;
+mod kdf;
+
+pub use kdf::derive_keygen_output;
+
+

--- a/src/eddsa/mod.rs
+++ b/src/eddsa/mod.rs
@@ -1,8 +1,23 @@
 //! This module serves as a wrapper for Frost protocol.
+
+use frost_core::keys::{PublicKeyPackage, SigningShare};
 use frost_ed25519::Ed25519Sha512;
 use crate::generic_dkg::{BytesOrder, Ciphersuite, ScalarSerializationFormat};
 
-pub type KeygenOutput = crate::generic_dkg::KeygenOutput<Ed25519Sha512>;
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct KeygenOutput {
+    pub private_share: SigningShare<Ed25519Sha512>,
+    pub public_key_package: PublicKeyPackage<Ed25519Sha512>,
+}
+
+impl From<crate::generic_dkg::KeygenOutput<Ed25519Sha512>> for KeygenOutput {
+    fn from(value: crate::generic_dkg::KeygenOutput<Ed25519Sha512>) -> Self {
+        Self {
+            private_share: value.private_share,
+            public_key_package: value.public_key_package,
+        }
+    }
+}
 
 impl ScalarSerializationFormat for Ed25519Sha512 {
     fn bytes_order() -> BytesOrder {

--- a/src/eddsa/sign.rs
+++ b/src/eddsa/sign.rs
@@ -32,8 +32,6 @@ fn construct_key_package(
     )
 }
 
-pub type SignatureOutput = Option<Signature>; // None for participants and Some for coordinator
-
 /// Returns a future that executes signature protocol for *the Coordinator*.
 ///
 /// WARNING: Extracted from FROST documentation:
@@ -43,14 +41,14 @@ pub type SignatureOutput = Option<Signature>; // None for participants and Some 
 /// creating a specific ciphersuite for this, and not just sending the hash
 /// as if it were the message.
 /// For reference, see how RFC 8032 handles "pre-hashing".
-async fn do_sign_coordinator(
+pub async fn do_sign_coordinator(
     mut chan: SharedChannel,
     participants: ParticipantList,
     threshold: usize,
     me: Participant,
     keygen_output: KeygenOutput,
     message: Vec<u8>,
-) -> Result<SignatureOutput, ProtocolError> {
+) -> Result<Signature, ProtocolError> {
     let mut seen = ParticipantCounter::new(&participants);
     let mut rng = OsRng;
 
@@ -115,7 +113,7 @@ async fn do_sign_coordinator(
     let signature = frost_ed25519::aggregate(&signing_package, &signature_shares, &vk_package)
         .map_err(|e| ProtocolError::AssertionFailed(e.to_string()))?;
 
-    Ok(Some(signature))
+    Ok(signature)
 }
 
 /// Returns a future that executes signature protocol for *a Participant*.
@@ -127,14 +125,14 @@ async fn do_sign_coordinator(
 /// creating a specific ciphersuite for this, and not just sending the hash
 /// as if it were the message.
 /// For reference, see how RFC 8032 handles "pre-hashing".
-async fn do_sign_participant(
+pub async fn do_sign_participant(
     mut chan: SharedChannel,
     threshold: usize,
     me: Participant,
     coordinator: Participant,
     keygen_output: KeygenOutput,
     message: Vec<u8>,
-) -> Result<SignatureOutput, ProtocolError> {
+) -> Result<(), ProtocolError> {
     let mut rng = OsRng;
     if coordinator == me {
         return Err(ProtocolError::AssertionFailed(
@@ -184,27 +182,17 @@ async fn do_sign_participant(
     chan.send_private(r2_wait_point, coordinator, &signature_share)
         .await;
 
-    Ok(None)
+    Ok(())
 }
 
-/// Depending on whether the current participant is a coordinator or not,
-/// runs the signature protocol as either a participant or a coordinator.
-///
-/// WARNING: Extracted from FROST documentation:
-/// In all of the main FROST ciphersuites, the entire message must be sent
-/// to participants. In some cases, where the message is too big, it may be
-/// necessary to send a hash of the message instead. We strongly suggest
-/// creating a specific ciphersuite for this, and not just sending the hash
-/// as if it were the message.
-/// For reference, see how RFC 8032 handles "pre-hashing".
-pub fn sign(
+pub fn sign_coordinator(
     participants: &[Participant],
     threshold: usize,
     me: Participant,
     coordinator: Participant,
     keygen_output: KeygenOutput,
     message: Vec<u8>,
-) -> Result<Box<dyn Protocol<Output = SignatureOutput>>, InitializationError> {
+) -> Result<impl Protocol<Output = Signature>, InitializationError> {
     if participants.len() < 2 {
         return Err(InitializationError::BadParameters(format!(
             "participant count cannot be < 2, found: {}",
@@ -232,13 +220,61 @@ pub fn sign(
 
     let ctx = Context::new();
     let chan = ctx.shared_channel();
-    if me == coordinator {
-        let fut = do_sign_coordinator(chan, participants, threshold, me, keygen_output, message);
-        Ok(Box::new(make_protocol(ctx, fut)))
-    } else {
-        let fut = do_sign_participant(chan, threshold, me, coordinator, keygen_output, message);
-        Ok(Box::new(make_protocol(ctx, fut)))
-    }
+    let fut = do_sign_coordinator(
+        chan,
+        participants,
+        threshold,
+        me,
+        keygen_output,
+        message,
+    );
+    Ok(make_protocol(ctx, fut))
+}
+
+pub fn sign_participant(
+    participants: &[Participant],
+    threshold: usize,
+    me: Participant,
+    coordinator: Participant,
+    keygen_output: KeygenOutput,
+    message: Vec<u8>,
+) -> Result<impl Protocol<Output=()>, InitializationError> {
+    if participants.len() < 2 {
+        return Err(InitializationError::BadParameters(format!(
+            "participant count cannot be < 2, found: {}",
+            participants.len()
+        )));
+    };
+    let Some(participants) = ParticipantList::new(participants) else {
+        return Err(InitializationError::BadParameters(
+            "Participants list contains duplicates".to_string(),
+        ));
+    };
+
+    // ensure my presence in the participant list
+    if !participants.contains(me) {
+        return Err(InitializationError::BadParameters(
+            format!("participant list must contain {me:?}")
+        ));
+    };
+    // ensure the coordinator is a participant
+    if !participants.contains(coordinator) {
+        return Err(InitializationError::BadParameters(
+            format!("participant list must contain coordinator {coordinator:?}")
+        ));
+    };
+
+    let ctx = Context::new();
+    let chan = ctx.shared_channel();
+    let fut = do_sign_participant(
+        chan,
+        threshold,
+        me,
+        coordinator,
+        keygen_output,
+        message,
+    );
+    Ok(make_protocol(ctx, fut))
 }
 
 #[cfg(test)]
@@ -255,9 +291,7 @@ mod tests {
     use crate::protocol::Participant;
     use std::error::Error;
 
-    use super::SignatureOutput;
-
-    fn assert_single_coordinator_result(data: Vec<(Participant, SignatureOutput)>) -> Signature {
+    fn assert_single_coordinator_result(data: Vec<(Participant, Option<Signature>)>) -> Signature {
         let mut signature = None;
         let count = data
             .iter()

--- a/src/eddsa/sign.rs
+++ b/src/eddsa/sign.rs
@@ -144,10 +144,7 @@ async fn do_sign_participant(
         ));
     }
 
-    // create signing share out of private_share
-    let signing_share = SigningShare::new(keygen_output.private_share.to_scalar());
-
-    let (nonces, commitments) = round1::commit(&signing_share, &mut rng);
+    let (nonces, commitments) = round1::commit(&keygen_output.private_share, &mut rng);
 
     // --- Round 1.
     // * Wait for an initial message from a coordinator.
@@ -179,7 +176,7 @@ async fn do_sign_participant(
     }
 
     let vk_package = keygen_output.public_key_package;
-    let key_package = construct_key_package(threshold, &me, &signing_share, &vk_package);
+    let key_package = construct_key_package(threshold, &me, &keygen_output.private_share, &vk_package);
 
     let signature_share = round2::sign(&signing_package, &nonces, &key_package)
         .map_err(|e| ProtocolError::AssertionFailed(e.to_string()))?;

--- a/src/generic_dkg.rs
+++ b/src/generic_dkg.rs
@@ -396,7 +396,7 @@ async fn do_keyshare<C: Ciphersuite>(
     secret: Scalar<C>,
     old_reshare_package: Option<(VerifyingKey<C>, ParticipantList)>,
     mut rng: OsRng,
-) -> Result<(SigningKey<C>, PublicKeyPackage<C>), ProtocolError> {
+) -> Result<(SigningShare<C>, PublicKeyPackage<C>), ProtocolError> {
     let mut all_commitments = ParticipantMap::new(&participants);
     let mut all_proofs = ParticipantMap::new(&participants);
 
@@ -541,8 +541,7 @@ async fn do_keyshare<C: Ciphersuite>(
 
     // Construct the keypairs
     // Construct the signing share
-    let signing_share = SigningKey::<C>::from_scalar(my_signing_share)
-        .map_err(|_| ProtocolError::MalformedSigningKey)?;
+    let signing_share = SigningShare::new(my_signing_share);
     // cannot fail as all_commitments at least contains my commitment
     let all_commitments_vec = all_full_commitments.into_vec_or_none().unwrap();
     let all_commitments_refs = all_commitments_vec.iter().collect();
@@ -585,7 +584,7 @@ async fn do_keyshare<C: Ciphersuite>(
 /// This contains our share of the private key, along with the public key.
 #[derive(Debug, Clone)]
 pub struct KeygenOutput<C: Ciphersuite> {
-    pub private_share: SigningKey<C>,
+    pub private_share: SigningShare<C>,
     pub public_key_package: PublicKeyPackage<C>,
 }
 
@@ -649,7 +648,7 @@ pub(crate) async fn do_reshare<C: Ciphersuite>(
     participants: ParticipantList,
     me: Participant,
     threshold: usize,
-    old_signing_key: Option<SigningKey<C>>,
+    old_signing_key: Option<SigningShare<C>>,
     old_public_key: VerifyingKey<C>,
     old_participants: ParticipantList,
 ) -> Result<KeygenOutput<C>, ProtocolError> {
@@ -684,7 +683,7 @@ pub(crate) fn reshare_assertions<C: Ciphersuite>(
     participants: &[Participant],
     me: Participant,
     threshold: usize,
-    old_signing_key: Option<SigningKey<C>>,
+    old_signing_key: Option<SigningShare<C>>,
     old_threshold: usize,
     old_participants: &[Participant],
 ) -> Result<(ParticipantList, ParticipantList), InitializationError> {

--- a/src/generic_dkg.rs
+++ b/src/generic_dkg.rs
@@ -582,7 +582,7 @@ async fn do_keyshare<C: Ciphersuite>(
 /// Represents the output of the key generation protocol.
 ///
 /// This contains our share of the private key, along with the public key.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct KeygenOutput<C: Ciphersuite> {
     pub private_share: SigningShare<C>,
     pub public_key_package: PublicKeyPackage<C>,

--- a/src/generic_dkg.rs
+++ b/src/generic_dkg.rs
@@ -13,6 +13,15 @@ use frost_core::{Challenge, Element, Error, Field, Group, Scalar, Signature, Sig
 use rand_core::OsRng;
 use std::ops::Index;
 
+/// Represents the output of the key generation protocol.
+///
+/// This contains our share of the private key, along with the public key.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct KeygenOutput<C: Ciphersuite> {
+    pub private_share: SigningShare<C>,
+    pub public_key_package: PublicKeyPackage<C>,
+}
+
 pub enum BytesOrder {
     BigEndian,
     LittleEndian,
@@ -577,15 +586,6 @@ async fn do_keyshare<C: Ciphersuite>(
 
     // unwrap cannot fail as round 4 ensures failing if verification_key is None
     Ok((signing_share, public_key_package))
-}
-
-/// Represents the output of the key generation protocol.
-///
-/// This contains our share of the private key, along with the public key.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct KeygenOutput<C: Ciphersuite> {
-    pub private_share: SigningShare<C>,
-    pub public_key_package: PublicKeyPackage<C>,
 }
 
 pub(crate) async fn do_keygen<C: Ciphersuite>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,3 +132,7 @@ pub use compat::CSCurve;
 
 pub mod ecdsa;
 pub mod eddsa;
+
+pub use frost_core;
+pub use frost_secp256k1;
+pub use frost_ed25519;


### PR DESCRIPTION
Stacked on top of #11 

### Overview 

#### Bring back original Keygen 

Migration to a new keygen type for existing ecdsa code requires a lot more refactoring than a couple of lines changes. I don't have resource for that at the moment + it's not a priority right now. It was easier to bring the type back.

#### Split sign_coordinator/sign_follower (again)
`Box<dyn Protocol<...>>` can not be used in `make_protocol`, as it requires concrete type of `impl Protocol`

#### Relax argument types

Change private share type for eddsa from `SigningKey` to `SigningShare` to avoid unnecessary unwraps (easier casts from `Scalar`)

#### Include eddsa kdf into the project structure