### PR TITLE
Simon/coordinator in ed25519sign

### DIFF
--- a/src/echo_broadcast.rs
+++ b/src/echo_broadcast.rs
@@ -263,7 +263,7 @@ where
 
                     // return a map of participant data
                     // the unwrap will not fail as the index is in the range of participants
-                    let p = participants.get_participant(&sid).unwrap();
+                    let p = participants.get_participant(sid).unwrap();
                     // make a list of data and return them
                     vote_output.put(p, data.clone());
 

--- a/src/eddsa/sign.rs
+++ b/src/eddsa/sign.rs
@@ -64,7 +64,6 @@ async fn do_sign_coordinator(
     let mut commitments_map: BTreeMap<frost_ed25519::Identifier, round1::SigningCommitments> =
         BTreeMap::new();
 
-
     let signing_share = SigningShare::new(keygen_output.private_share.to_scalar());
 
     let (nonces, commitments) = round1::commit(&signing_share, &mut rng);
@@ -315,29 +314,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn multiple_coordinators() {
-        let max_signers = 3;
-        let threshold = 2;
-        let actual_signers = 2;
-        let msg = "hello_near";
-        let msg_hash = hash(&msg);
-
-        let key_packages = build_key_packages_with_dealer(max_signers, threshold);
-        // two coordinators
-        let coordinators = vec!(key_packages[0].0, key_packages[1].0);
-        let data = test_run_signature_protocols(
-            &key_packages,
-            actual_signers,
-            &coordinators,
-            threshold,
-            msg_hash,
-        )
-        .unwrap();
-        assert_single_coordinator_result(data);
-    }
-
-    #[test]
     fn stress() {
         let max_signers = 7;
         let msg = "hello_near";
@@ -464,7 +440,6 @@ mod tests {
         let result0 = run_keygen(&participants, threshold)?;
         assert_public_key_invariant(&result0)?;
 
-        let coordinators = vec!(result0[0].0);
         let pub_key = result0[2].1.public_key_package.clone();
 
         // Run heavy reshare
@@ -510,6 +485,7 @@ mod tests {
         let msg = "hello_near";
         let msg_hash = hash(&msg);
 
+        let coordinators = vec!(key_packages[0].0);
         let data = test_run_signature_protocols(
             &key_packages,
             actual_signers,

--- a/src/eddsa/test.rs
+++ b/src/eddsa/test.rs
@@ -1,17 +1,15 @@
 use crate::eddsa::dkg_ed25519::{keygen, refresh, reshare};
-use crate::eddsa::sign::{do_sign_coordinator, do_sign_participant};
+use crate::eddsa::sign::{sign, SignatureOutput};
 use crate::eddsa::KeygenOutput;
 use crate::participants::ParticipantList;
-use crate::protocol::internal::{make_protocol, Context, SharedChannel};
-use crate::protocol::{run_protocol, Participant, Protocol, ProtocolError};
+use crate::protocol::{run_protocol, Participant, Protocol};
 
 use frost_ed25519::keys::{PublicKeyPackage, VerifyingShare};
-use frost_ed25519::{Group, Signature, SigningKey};
+use frost_ed25519::{Group, SigningKey};
 use rand_core::{OsRng, RngCore};
 use std::error::Error;
 
 use crate::crypto::Digest;
-pub(crate) type IsSignature = Option<Signature>;
 
 /// this is a centralized key generation
 pub(crate) fn build_key_packages_with_dealer(
@@ -146,87 +144,14 @@ pub(crate) fn run_reshare(
     Ok(result)
 }
 
-/// similar to do_sign_participant except
-/// it outputs the same type as do_sign_coordinator_test
-async fn do_sign_participant_test(
-    chan: SharedChannel,
-    threshold: usize,
-    me: Participant,
-    keygen_output: KeygenOutput,
-    message: Vec<u8>,
-) -> Result<IsSignature, ProtocolError> {
-    do_sign_participant(chan, threshold, me, keygen_output, message).await?;
-    Ok(None)
-}
-
-/// similar to do_sign_coordinator except
-/// it outputs the same type as do_sign_participant_test
-async fn do_sign_coordinator_test(
-    chan: SharedChannel,
-    participants: ParticipantList,
-    threshold: usize,
-    me: Participant,
-    keygen_output: KeygenOutput,
-    message: Vec<u8>,
-) -> Result<IsSignature, ProtocolError> {
-    let sig =
-        do_sign_coordinator(chan, participants, threshold, me, keygen_output, message).await?;
-    Ok(Some(sig))
-}
-
-fn sign_test(
-    participants: Vec<Participant>,
-    threshold: usize,
-    me: Participant,
-    keygen_output: KeygenOutput,
-    message: Vec<u8>,
-    is_coordinator: bool,
-) -> Result<Box<dyn Protocol<Output = IsSignature>>, ProtocolError> {
-    if participants.len() < 2 {
-        return Err(ProtocolError::AssertionFailed(format!(
-            "participant count cannot be < 2, found: {}",
-            participants.len()
-        )));
-    };
-    let Some(participants) = ParticipantList::new(&participants) else {
-        return Err(ProtocolError::AssertionFailed(format!(
-            "Participants list contains duplicates",
-        )));
-    };
-
-    // ensure my presence in the participant list
-    if !participants.contains(me) {
-        return Err(ProtocolError::AssertionFailed(
-            "participant list must contain this participant".to_string(),
-        ));
-    };
-
-    let ctx = Context::new();
-    if is_coordinator {
-        let fut = do_sign_coordinator_test(
-            ctx.shared_channel(),
-            participants,
-            threshold,
-            me,
-            keygen_output,
-            message,
-        );
-        Ok(Box::new(make_protocol(ctx, fut)))
-    } else {
-        let fut =
-            do_sign_participant_test(ctx.shared_channel(), threshold, me, keygen_output, message);
-        Ok(Box::new(make_protocol(ctx, fut)))
-    }
-}
-
-pub(crate) fn run_signature_protocols(
+pub(crate) fn test_run_signature_protocols(
     participants: &[(Participant, KeygenOutput)],
     actual_signers: usize,
-    coordinators_count: usize,
+    coordinators: &[Participant],
     threshold: usize,
     msg_hash: Digest,
-) -> Result<Vec<(Participant, IsSignature)>, Box<dyn Error>> {
-    let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = IsSignature>>)> =
+) -> Result<Vec<(Participant, SignatureOutput)>, Box<dyn Error>> {
+    let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = SignatureOutput>>)> =
         Vec::with_capacity(participants.len());
 
     let participants_list = participants
@@ -234,18 +159,34 @@ pub(crate) fn run_signature_protocols(
         .take(actual_signers)
         .map(|(id, _)| *id)
         .collect::<Vec<_>>();
-
-    for (idx, (participant, key_pair)) in participants.iter().take(actual_signers).enumerate() {
-        let protocol: Box<dyn Protocol<Output = IsSignature>> = sign_test(
-            participants_list.clone(),
-            threshold,
-            *participant,
-            key_pair.clone(),
-            msg_hash.as_ref().to_vec(),
-            idx < coordinators_count,
-        )?;
-
+    let coordinators = ParticipantList::new(&coordinators).unwrap();
+    for (participant, key_pair) in participants.iter().take(actual_signers) {
+        let protocol = if coordinators.contains(*participant){
+            sign(
+                &participants_list,
+                threshold,
+                *participant,
+                *participant,
+                key_pair.clone(),
+                msg_hash.as_ref().to_vec(),
+            )?
+        } else {
+            // pick any coordinator
+            let mut rng = OsRng;
+            let index = rng.next_u32() as usize % coordinators.len();
+            let coordinator = coordinators.get_participant(index).unwrap();
+            // run the signing scheme
+            sign(
+                &participants_list,
+                threshold,
+                *participant,
+                coordinator,
+                key_pair.clone(),
+                msg_hash.as_ref().to_vec(),
+            )?
+        };
         protocols.push((*participant, protocol))
+
     }
 
     Ok(run_protocol(protocols)?)

--- a/src/participants.rs
+++ b/src/participants.rs
@@ -74,11 +74,11 @@ impl ParticipantList {
 
     // Return a participant of a given index from the order they
     // appear in the sorted list
-    pub fn get_participant(&self, index: &usize) -> Option<Participant> {
-        if *index >= self.participants.len() {
+    pub fn get_participant(&self, index: usize) -> Option<Participant> {
+        if index >= self.participants.len() {
             return None;
         }
-        Some(self.participants[*index])
+        Some(self.participants[index])
     }
 
     /// Get the lagrange coefficient for a participant, relative to this list.


### PR DESCRIPTION
In this PR I get rid of deciding the coordinator in the signing function.
This has to be given as input to the signing algorithm. Additionally now a single sign function shall be used.
Internally this function decides whether the coordinator sign should be run or the participant sign is the one to run.

Please modify NearOne-mpc Accordingly