### PR TITLE
Simon/dkg commitment hash round

### DIFF
--- a/src/eddsa/sign.rs
+++ b/src/eddsa/sign.rs
@@ -69,7 +69,8 @@ async fn do_sign_coordinator(
 
     let commit_waitpoint = chan.next_waitpoint();
     while !seen.full() {
-        let (from, commitment): (_, round1::SigningCommitments) = chan.recv(commit_waitpoint).await?;
+        let (from, commitment): (_, round1::SigningCommitments) =
+            chan.recv(commit_waitpoint).await?;
 
         if !seen.put(from) {
             continue;
@@ -138,8 +139,9 @@ async fn do_sign_participant(
     if coordinator == me {
         return Err(ProtocolError::AssertionFailed(
             "the do_sign_participant function cannot be called
-            for a coordinator".to_string()
-        ))
+            for a coordinator"
+                .to_string(),
+        ));
     }
 
     // create signing share out of private_share
@@ -220,42 +222,27 @@ pub fn sign(
 
     // ensure my presence in the participant list
     if !participants.contains(me) {
-        return Err(InitializationError::BadParameters(
-            format!("participant list must contain {me:?}")
-        ));
+        return Err(InitializationError::BadParameters(format!(
+            "participant list must contain {me:?}"
+        )));
     };
     // ensure the coordinator is a participant
     if !participants.contains(coordinator) {
-        return Err(InitializationError::BadParameters(
-            format!("participant list must contain coordinator {coordinator:?}")
-        ));
+        return Err(InitializationError::BadParameters(format!(
+            "participant list must contain coordinator {coordinator:?}"
+        )));
     };
 
     let ctx = Context::new();
     let chan = ctx.shared_channel();
-    if me == coordinator{
-        let fut = do_sign_coordinator(
-            chan,
-            participants,
-            threshold,
-            me,
-            keygen_output,
-            message,
-        );
+    if me == coordinator {
+        let fut = do_sign_coordinator(chan, participants, threshold, me, keygen_output, message);
         Ok(Box::new(make_protocol(ctx, fut)))
     } else {
-        let fut = do_sign_participant(
-            chan,
-            threshold,
-            me,
-            coordinator,
-            keygen_output,
-            message
-        );
+        let fut = do_sign_participant(chan, threshold, me, coordinator, keygen_output, message);
         Ok(Box::new(make_protocol(ctx, fut)))
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -266,7 +253,7 @@ mod tests {
 
     use crate::eddsa::test::{
         assert_public_key_invariant, build_key_packages_with_dealer, run_keygen, run_refresh,
-        run_reshare, test_run_signature_protocols
+        run_reshare, test_run_signature_protocols,
     };
     use crate::protocol::Participant;
     use std::error::Error;
@@ -298,7 +285,7 @@ mod tests {
         let msg_hash = hash(&msg);
 
         let key_packages = build_key_packages_with_dealer(max_signers, threshold);
-        let coordinators = vec!(key_packages[0].0);
+        let coordinators = vec![key_packages[0].0];
         let data = test_run_signature_protocols(
             &key_packages,
             actual_signers,
@@ -319,7 +306,7 @@ mod tests {
         for min_signers in 2..max_signers {
             for actual_signers in min_signers..=max_signers {
                 let key_packages = build_key_packages_with_dealer(max_signers, min_signers);
-                let coordinators = vec!(key_packages[0].0);
+                let coordinators = vec![key_packages[0].0];
                 let data = test_run_signature_protocols(
                     &key_packages,
                     actual_signers,
@@ -349,7 +336,7 @@ mod tests {
         // test dkg
         let key_packages = run_keygen(&participants, threshold)?;
         assert_public_key_invariant(&key_packages)?;
-        let coordinators = vec!(key_packages[0].0);
+        let coordinators = vec![key_packages[0].0];
         let data = test_run_signature_protocols(
             &key_packages,
             actual_signers,
@@ -404,7 +391,7 @@ mod tests {
         assert_public_key_invariant(&key_packages2)?;
         let msg = "hello_near_3";
         let msg_hash = hash(&msg);
-        let coordinators = vec!(key_packages2[0].0);
+        let coordinators = vec![key_packages2[0].0];
         let data = test_run_signature_protocols(
             &key_packages2,
             actual_signers,
@@ -482,7 +469,7 @@ mod tests {
         let msg = "hello_near";
         let msg_hash = hash(&msg);
 
-        let coordinators = vec!(key_packages[0].0);
+        let coordinators = vec![key_packages[0].0];
         let data = test_run_signature_protocols(
             &key_packages,
             actual_signers,
@@ -513,7 +500,7 @@ mod tests {
         let threshold = 4;
         let result0 = run_keygen(&participants, threshold)?;
         assert_public_key_invariant(&result0)?;
-        let coordinators = vec!(result0[0].0);
+        let coordinators = vec![result0[0].0];
 
         let pub_key = result0[2].1.public_key_package.clone();
 

--- a/src/eddsa/test.rs
+++ b/src/eddsa/test.rs
@@ -161,7 +161,7 @@ pub(crate) fn test_run_signature_protocols(
         .collect::<Vec<_>>();
     let coordinators = ParticipantList::new(&coordinators).unwrap();
     for (participant, key_pair) in participants.iter().take(actual_signers) {
-        let protocol = if coordinators.contains(*participant){
+        let protocol = if coordinators.contains(*participant) {
             sign(
                 &participants_list,
                 threshold,
@@ -186,7 +186,6 @@ pub(crate) fn test_run_signature_protocols(
             )?
         };
         protocols.push((*participant, protocol))
-
     }
 
     Ok(run_protocol(protocols)?)

--- a/src/generic_dkg.rs
+++ b/src/generic_dkg.rs
@@ -220,8 +220,8 @@ fn verify_commitment_hash<C: Ciphersuite>(
 ) -> Result<(), ProtocolError> {
     let actual_commitment_hash = all_hash_commitments.index(participant);
     let commitment_hash = hash(&commitment);
-    if *actual_commitment_hash != commitment_hash{
-        return Err(ProtocolError::InvalidCommitmentHash)
+    if *actual_commitment_hash != commitment_hash {
+        return Err(ProtocolError::InvalidCommitmentHash);
     }
     Ok(())
 }
@@ -425,9 +425,9 @@ async fn do_keyshare<C: Ciphersuite>(
     let mut all_hash_commitments = ParticipantMap::new(&participants);
     all_hash_commitments.put(me, commitment_hash);
     while !all_hash_commitments.full() {
-       let (from, their_commitment_hash) = chan.recv(wait_round_1).await?;
-       all_hash_commitments.put(from, their_commitment_hash);
-   }
+        let (from, their_commitment_hash) = chan.recv(wait_round_1).await?;
+        all_hash_commitments.put(from, their_commitment_hash);
+    }
 
     // Start Round 2
     // add my commitment and proof to the map
@@ -470,7 +470,8 @@ async fn do_keyshare<C: Ciphersuite>(
         // using the evaluation secret polynomial on the identifier of the recipient
         let signing_share_to_p = evaluate_polynomial::<C>(&secret_coefficients, p)?;
         // send the evaluation privately to participant p
-        chan.send_private(wait_round_3, p, &signing_share_to_p).await;
+        chan.send_private(wait_round_3, p, &signing_share_to_p)
+            .await;
     }
 
     // compute transcript hash

--- a/src/generic_dkg.rs
+++ b/src/generic_dkg.rs
@@ -211,6 +211,21 @@ fn verify_proof_of_knowledge<C: Ciphersuite>(
         .map_err(|_| ProtocolError::InvalidProofOfKnowledge(participant))
 }
 
+/// Takes a commitment and a commitment hash and checks that
+/// H(commitment) = commitment_hash
+fn verify_commitment_hash<C: Ciphersuite>(
+    participant: Participant,
+    commitment: &VerifiableSecretSharingCommitment<C>,
+    all_hash_commitments: &ParticipantMap<'_, Digest>,
+) -> Result<(), ProtocolError> {
+    let actual_commitment_hash = all_hash_commitments.index(participant);
+    let commitment_hash = hash(&commitment);
+    if *actual_commitment_hash != commitment_hash{
+        return Err(ProtocolError::InvalidCommitmentHash)
+    }
+    Ok(())
+}
+
 /// This function is called when the commitment length is threshold -1
 /// i.e. when the new participant sent a polynomial with a non-existant constant term
 /// such a participant would do so as the identity is not serializable
@@ -402,6 +417,19 @@ async fn do_keyshare<C: Ciphersuite>(
     // Create the public polynomial = secret coefficients times G
     let commitment = VerifiableSecretSharingCommitment::new(coefficient_commitment);
 
+    // hash commitment and send it
+    let commitment_hash = hash(&commitment);
+    let wait_round_1 = chan.next_waitpoint();
+    chan.send_many(wait_round_1, &commitment_hash).await;
+    // receive commitment_hash
+    let mut all_hash_commitments = ParticipantMap::new(&participants);
+    all_hash_commitments.put(me, commitment_hash);
+    while !all_hash_commitments.full() {
+       let (from, their_commitment_hash) = chan.recv(wait_round_1).await?;
+       all_hash_commitments.put(from, their_commitment_hash);
+   }
+
+    // Start Round 2
     // add my commitment and proof to the map
     all_commitments.put(me, commitment.clone());
     all_proofs.put(me, proof_of_knowledge);
@@ -415,8 +443,8 @@ async fn do_keyshare<C: Ciphersuite>(
     )
     .await?;
 
-    // Start Round 2
-    let wait_round2 = chan.next_waitpoint();
+    // Start Round 3
+    let wait_round_3 = chan.next_waitpoint();
     for p in participants.others(me) {
         let (commitment_i, proof_i) = commitments_and_proofs_map.index(p);
 
@@ -431,6 +459,9 @@ async fn do_keyshare<C: Ciphersuite>(
             proof_i,
         )?;
 
+        // verify that the commitment sent hashes to the received commitment_hash in round 1
+        verify_commitment_hash(p, commitment_i, &all_hash_commitments)?;
+
         // add received commitment and proof to the map
         all_commitments.put(p, commitment_i.clone());
         all_proofs.put(p, *proof_i);
@@ -439,7 +470,7 @@ async fn do_keyshare<C: Ciphersuite>(
         // using the evaluation secret polynomial on the identifier of the recipient
         let signing_share_to_p = evaluate_polynomial::<C>(&secret_coefficients, p)?;
         // send the evaluation privately to participant p
-        chan.send_private(wait_round2, p, &signing_share_to_p).await;
+        chan.send_private(wait_round_3, p, &signing_share_to_p).await;
     }
 
     // compute transcript hash
@@ -459,7 +490,7 @@ async fn do_keyshare<C: Ciphersuite>(
     seen.put(me);
     while !seen.full() {
         let (from, signing_share_from): (Participant, SigningShare<C>) =
-            chan.recv(wait_round2).await?;
+            chan.recv(wait_round_3).await?;
         if !seen.put(from) {
             continue;
         }
@@ -481,8 +512,7 @@ async fn do_keyshare<C: Ciphersuite>(
         my_signing_share = my_signing_share + signing_share_from.to_scalar();
     }
 
-    // Start Round 3
-
+    // Start Round 4
     // receive all transcript hashes
     let transcript_list = do_broadcast(&mut chan, &participants, &me, my_transcript).await?;
     let transcript_list = transcript_list.into_vec_or_none().unwrap();
@@ -532,9 +562,8 @@ async fn do_keyshare<C: Ciphersuite>(
         };
     };
 
-    // Start Round 4
+    // Start Round 5
     broadcast_success_failure(&mut chan, &participants, &me, err).await?;
-
     // will never panic as broadcast_success_failure would panic before it
     let public_key_package = public_key_package.unwrap();
 

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -53,7 +53,10 @@ impl fmt::Display for ProtocolError {
                 "could not extract the verification Key from the commitment."
             ),
             ProtocolError::InvalidCommitmentHash => {
-                write!(f, "the sent commitment_hash does not equals the hash of the commitment")
+                write!(
+                    f,
+                    "the sent commitment_hash does not equals the hash of the commitment"
+                )
             }
             ProtocolError::IncorrectNumberOfCommitments => {
                 write!(f, "incorrect number of commitments")

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -22,6 +22,8 @@ pub enum ProtocolError {
     DKGNotSupported,
     /// Could not extract the verification Key from a commitment.
     ErrorExtractVerificationKey,
+    /// The sent commitment hash does not equal the hash of the sent commitment
+    InvalidCommitmentHash,
     /// Incorrect number of commitments.
     IncorrectNumberOfCommitments,
     /// The identifier of the signer whose share validation failed.
@@ -50,6 +52,9 @@ impl fmt::Display for ProtocolError {
                 f,
                 "could not extract the verification Key from the commitment."
             ),
+            ProtocolError::InvalidCommitmentHash => {
+                write!(f, "the sent commitment_hash does not equals the hash of the commitment")
+            }
             ProtocolError::IncorrectNumberOfCommitments => {
                 write!(f, "incorrect number of commitments")
             }


### PR DESCRIPTION
Adding Round for hashing the commitments before sending them.
Then later checking that the hashes match.
This is necessary to prove the security of DKG for ECDSA