### PR TITLE
Directly use futures instead of executor in cait-sith protocol implementations

### DIFF
--- a/src/ecdsa/dkg_ecdsa.rs
+++ b/src/ecdsa/dkg_ecdsa.rs
@@ -3,7 +3,7 @@ use frost_secp256k1::*;
 
 use crate::ecdsa::KeygenOutput;
 use crate::generic_dkg::*;
-use crate::protocol::internal::{make_protocol, Context};
+use crate::protocol::internal::{make_protocol, Comms};
 use crate::protocol::{InitializationError, Participant, Protocol};
 use futures::FutureExt;
 
@@ -15,7 +15,7 @@ pub fn keygen(
     me: Participant,
     threshold: usize,
 ) -> Result<impl Protocol<Output = KeygenOutput>, InitializationError> {
-    let ctx = Context::new();
+    let ctx = Comms::new();
     let participants = assert_keygen_invariants(participants, me, threshold)?;
     let fut =
         do_keygen(ctx.shared_channel(), participants, me, threshold).map(|x| x.map(Into::into));
@@ -32,7 +32,7 @@ pub fn reshare(
     new_threshold: usize,
     me: Participant,
 ) -> Result<impl Protocol<Output = KeygenOutput>, InitializationError> {
-    let ctx = Context::new();
+    let ctx = Comms::new();
     let threshold = new_threshold;
     let (participants, old_participants) = reshare_assertions::<E>(
         new_participants,
@@ -68,7 +68,7 @@ pub fn refresh(
             "The participant {me:?} is running refresh without an old share",
         )));
     }
-    let ctx = Context::new();
+    let ctx = Comms::new();
     let threshold = new_threshold;
     let (participants, old_participants) = reshare_assertions::<E>(
         new_participants,

--- a/src/ecdsa/presign.rs
+++ b/src/ecdsa/presign.rs
@@ -2,7 +2,7 @@ use crate::compat::CSCurve;
 use crate::ecdsa::triples::{TriplePub, TripleShare};
 use crate::ecdsa::KeygenOutput;
 use crate::participants::ParticipantCounter;
-use crate::protocol::internal::{make_protocol, Context, SharedChannel};
+use crate::protocol::internal::{make_protocol, Comms, SharedChannel};
 use crate::protocol::{InitializationError, Protocol};
 use crate::{
     participants::ParticipantList,
@@ -104,7 +104,7 @@ async fn do_presign<C: CSCurve>(
     let wait0 = chan.next_waitpoint();
     {
         let kd_i: ScalarPrimitive<C> = kd_i.into();
-        chan.send_many(wait0, &kd_i).await;
+        chan.send_many(wait0, &kd_i);
     }
 
     // Spec 1.9
@@ -116,7 +116,7 @@ async fn do_presign<C: CSCurve>(
     {
         let ka_i: ScalarPrimitive<C> = ka_i.into();
         let xb_i: ScalarPrimitive<C> = xb_i.into();
-        chan.send_many(wait1, &(ka_i, xb_i)).await;
+        chan.send_many(wait1, &(ka_i, xb_i));
     }
 
     // Spec 2.1 and 2.2
@@ -233,7 +233,7 @@ pub fn presign<C: CSCurve>(
         )
     })?;
 
-    let ctx = Context::new();
+    let ctx = Comms::new();
     let fut = do_presign(
         ctx.shared_channel(),
         participants,

--- a/src/ecdsa/sign.rs
+++ b/src/ecdsa/sign.rs
@@ -1,12 +1,13 @@
 use elliptic_curve::{ops::Invert, scalar::IsHigh, Field, Group, ScalarPrimitive};
 use subtle::ConditionallySelectable;
 
+use crate::protocol::internal::Comms;
 use crate::{
     compat::{self, CSCurve},
     ecdsa::presign::PresignOutput,
     participants::{ParticipantCounter, ParticipantList},
     protocol::{
-        internal::{make_protocol, Context, SharedChannel},
+        internal::{make_protocol, SharedChannel},
         InitializationError, Participant, Protocol, ProtocolError,
     },
 };
@@ -67,7 +68,7 @@ async fn do_sign<C: CSCurve>(
     let wait0 = chan.next_waitpoint();
     {
         let s_i: ScalarPrimitive<C> = s_i.into();
-        chan.send_many(wait0, &s_i).await;
+        chan.send_many(wait0, &s_i);
     }
 
     // Spec 2.1 + 2.2
@@ -174,7 +175,7 @@ pub fn sign<C: CSCurve>(
         InitializationError::BadParameters("participant list cannot contain duplicates".to_string())
     })?;
 
-    let ctx = Context::new();
+    let ctx = Comms::new();
     let fut = do_sign(
         ctx.shared_channel(),
         participants,

--- a/src/ecdsa/triples/mta.rs
+++ b/src/ecdsa/triples/mta.rs
@@ -5,10 +5,11 @@ use serde::{Deserialize, Serialize};
 use std::slice::Iter;
 use subtle::{Choice, ConditionallySelectable};
 
+use crate::protocol::internal::Comms;
 use crate::{
     compat::CSCurve,
     protocol::{
-        internal::{make_protocol, Context, PrivateChannel},
+        internal::{make_protocol, PrivateChannel},
         run_two_party_protocol, Participant, ProtocolError,
     },
 };
@@ -78,7 +79,7 @@ pub async fn mta_sender<C: CSCurve>(
             .collect(),
     );
     let wait0 = chan.next_waitpoint();
-    chan.send(wait0, &c).await;
+    chan.send(wait0, &c);
 
     // Step 7
     let wait1 = chan.next_waitpoint();
@@ -138,7 +139,7 @@ pub async fn mta_receiver<C: CSCurve>(
     // Step 6
     let wait1 = chan.next_waitpoint();
     let chi1: ScalarPrimitive<C> = chi1.into();
-    chan.send(wait1, &(chi1, seed)).await;
+    chan.send(wait1, &(chi1, seed));
 
     Ok(beta)
 }
@@ -151,8 +152,8 @@ fn run_mta<C: CSCurve>(
 ) -> Result<(C::Scalar, C::Scalar), ProtocolError> {
     let s = Participant::from(0u32);
     let r = Participant::from(1u32);
-    let ctx_s = Context::new();
-    let ctx_r = Context::new();
+    let ctx_s = Comms::new();
+    let ctx_r = Comms::new();
 
     run_two_party_protocol(
         s,

--- a/src/echo_broadcast.rs
+++ b/src/echo_broadcast.rs
@@ -92,7 +92,7 @@ where
     let vote = MessageType::Send(data);
     let sid = participants.index(me);
     // Send vote to all participants but for myself
-    chan.send_many(wait, &(&sid, &vote)).await;
+    chan.send_many(wait, &(&sid, &vote));
     // the vote is returned to be taken into consideration as received
     vote
 }
@@ -174,7 +174,7 @@ where
                 }
                 vote = MessageType::Echo(data);
                 // upon receiving a send message, echo it
-                chan.send_many(wait, &(&sid, &vote)).await;
+                chan.send_many(wait, &(&sid, &vote));
                 finish_send[sid] = true;
 
                 // simulate an echo vote sent by me
@@ -195,7 +195,7 @@ where
                 // for a result, deliver Ready
                 if data_echo[sid].get(&data).unwrap() > echo_t {
                     vote = MessageType::Ready(data);
-                    chan.send_many(wait, &(&sid, &vote)).await;
+                    chan.send_many(wait, &(&sid, &vote));
                     // state that the echo phase for session id (sid) is done
                     finish_echo[sid] = true;
 
@@ -248,7 +248,7 @@ where
                 // proceed to amplification of the ready message
                 if data_ready[sid].get(&data).unwrap() > ready_t && !finish_amplification[sid] {
                     vote = MessageType::Ready(data.clone());
-                    chan.send_many(wait, &(&sid, &vote)).await;
+                    chan.send_many(wait, &(&sid, &vote));
                     finish_amplification[sid] = true;
 
                     // simulate a ready vote sent by me
@@ -311,7 +311,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::protocol::internal::{make_protocol, Context};
+    use crate::protocol::internal::{make_protocol, Comms};
     use crate::protocol::{run_protocol, Protocol, ProtocolError};
     use std::error::Error;
 
@@ -347,11 +347,11 @@ mod test {
                 "Does not contain me"
             )));
         }
-        let ctx = Context::new();
-        let chan = ctx.shared_channel();
+        let comms = Comms::new();
+        let chan = comms.shared_channel();
         let fut = do_broadcast_consume(chan, participants, me, data);
 
-        Ok(make_protocol(ctx, fut))
+        Ok(make_protocol(comms, fut))
     }
 
     /// All participants are assumed to be honest here
@@ -388,11 +388,9 @@ mod test {
         let mut cnt = 0;
         for p in participants.others(me) {
             if cnt >= participants.len() / 2 {
-                chan.send_private(wait_broadcast, p, &(&sid, &vote_false))
-                    .await;
+                chan.send_private(wait_broadcast, p, &(&sid, &vote_false));
             } else {
-                chan.send_private(wait_broadcast, p, &(&sid, &vote_true))
-                    .await;
+                chan.send_private(wait_broadcast, p, &(&sid, &vote_true));
             }
             cnt += 1;
         }
@@ -419,11 +417,9 @@ mod test {
         let mut cnt = 0;
         for p in participants.others(me) {
             if cnt >= participants.len() / 2 {
-                chan.send_private(wait_broadcast, p, &(&sid, &vote_false))
-                    .await;
+                chan.send_private(wait_broadcast, p, &(&sid, &vote_false));
             } else {
-                chan.send_private(wait_broadcast, p, &(&sid, &vote_true))
-                    .await;
+                chan.send_private(wait_broadcast, p, &(&sid, &vote_true));
             }
             cnt += 1;
         }
@@ -448,12 +444,12 @@ mod test {
                 "Does not contain me"
             )));
         }
-        let ctx = Context::new();
-        let chan = ctx.shared_channel();
+        let comms = Comms::new();
+        let chan = comms.shared_channel();
 
         let fut = do_broadcast_dishonest_consume_version_1(chan, participants, me);
 
-        Ok(make_protocol(ctx, fut))
+        Ok(make_protocol(comms, fut))
     }
 
     #[allow(clippy::type_complexity)]
@@ -469,12 +465,12 @@ mod test {
                 "Does not contain me"
             )));
         }
-        let ctx = Context::new();
-        let chan = ctx.shared_channel();
+        let comms = Comms::new();
+        let chan = comms.shared_channel();
 
         let fut = do_broadcast_dishonest_consume_version_2(chan, participants, me);
 
-        Ok(make_protocol(ctx, fut))
+        Ok(make_protocol(comms, fut))
     }
 
     fn broadcast_dishonest_v1(

--- a/src/generic_dkg.rs
+++ b/src/generic_dkg.rs
@@ -5,8 +5,7 @@ use crate::protocol::internal::SharedChannel;
 use crate::protocol::{InitializationError, Participant, ProtocolError};
 
 use frost_core::keys::{
-    CoefficientCommitment, SecretShare, SigningShare,
-    VerifiableSecretSharingCommitment,
+    CoefficientCommitment, SecretShare, SigningShare, VerifiableSecretSharingCommitment,
 };
 use frost_core::{
     Challenge, Element, Error, Field, Group, Scalar, Signature, SigningKey, VerifyingKey,
@@ -446,7 +445,7 @@ async fn do_keyshare<C: Ciphersuite>(
     let commit_domain_separator = domain_separator;
     let commitment_hash = domain_separate_hash(domain_separator, &(&me, &commitment, &session_id));
     let wait_round_1 = chan.next_waitpoint();
-    chan.send_many(wait_round_1, &commitment_hash).await;
+    chan.send_many(wait_round_1, &commitment_hash);
     // receive commitment_hash
     let mut all_hash_commitments = ParticipantMap::new(&participants);
     all_hash_commitments.put(me, commitment_hash);
@@ -502,8 +501,7 @@ async fn do_keyshare<C: Ciphersuite>(
         // using the evaluation secret polynomial on the identifier of the recipient
         let signing_share_to_p = evaluate_polynomial::<C>(&secret_coefficients, p)?;
         // send the evaluation privately to participant p
-        chan.send_private(wait_round_3, p, &signing_share_to_p)
-            .await;
+        chan.send_private(wait_round_3, p, &signing_share_to_p);
     }
 
     // compute the my secret evaluation of my private polynomial

--- a/src/protocol/internal.rs
+++ b/src/protocol/internal.rs
@@ -56,6 +56,7 @@ use std::{collections::HashMap, error, future::Future, sync::Arc};
 use crate::serde::{decode, encode_with_tag};
 
 use super::{Action, MessageData, Participant, Protocol, ProtocolError};
+use smol::pin;
 
 /// The domain for our use of meow here.
 const MEOW_DOMAIN: &[u8] = b"cait-sith channel tags";
@@ -464,6 +465,7 @@ impl<'a> Context<'a> {
 struct ProtocolExecutor<'a, T> {
     ctx: Context<'a>,
     ret_r: channel::Receiver<Result<T, ProtocolError>>,
+    cancel_sender: Option<futures::channel::oneshot::Sender<()>>,
     done: bool,
 }
 
@@ -473,8 +475,14 @@ impl<'a, T: Send + 'a> ProtocolExecutor<'a, T> {
         fut: impl Future<Output = Result<T, ProtocolError>> + Send + 'a,
     ) -> Self {
         let (ret_s, ret_r) = smol::channel::bounded(1);
+        let (cancel_sender, cancel_receiver) = futures::channel::oneshot::channel::<()>();
         let fut = async move {
-            let res = fut.await;
+            pin!(fut);
+            let res = futures::future::select(fut, cancel_receiver).await;
+            let res = match res {
+                futures::future::Either::Left((res, _)) => res,
+                futures::future::Either::Right(_) => Err(ProtocolError::Cancelled),
+            };
             ret_s
                 .send(res)
                 .await
@@ -486,7 +494,16 @@ impl<'a, T: Send + 'a> ProtocolExecutor<'a, T> {
         Self {
             ctx,
             ret_r,
+            cancel_sender: Some(cancel_sender),
             done: false,
+        }
+    }
+}
+
+impl<'a, T> Drop for ProtocolExecutor<'a, T> {
+    fn drop(&mut self) {
+        if let Some(cancel_sender) = self.cancel_sender.take() {
+            cancel_sender.send(()).ok();
         }
     }
 }

--- a/src/protocol/internal.rs
+++ b/src/protocol/internal.rs
@@ -41,22 +41,17 @@
 //! agree on what the identifier for the channels in each part of the protocol is.
 //! This is why we have to take great care that the identifiers a protocol will produce
 //! are deterministic, even in the presence of concurrent tasks.
-use ck_meow::Meow;
-use event_listener::Event;
-use serde::{de::DeserializeOwned, Serialize};
-use smol::{
-    block_on,
-    channel::{self, Receiver, Sender},
-    future,
-    lock::Mutex,
-    Executor, Task,
-};
-use std::{collections::HashMap, error, future::Future, sync::Arc};
-
-use crate::serde::{decode, encode_with_tag};
-
 use super::{Action, MessageData, Participant, Protocol, ProtocolError};
-use smol::pin;
+use crate::serde::{decode, encode_with_tag};
+use ck_meow::Meow;
+use futures::future::BoxFuture;
+use futures::task::noop_waker;
+use futures::{FutureExt, StreamExt};
+use serde::{de::DeserializeOwned, Serialize};
+use smol::{future, lock::Mutex};
+use std::collections::VecDeque;
+use std::task::Context;
+use std::{collections::HashMap, error, future::Future, sync::Arc};
 
 /// The domain for our use of meow here.
 const MEOW_DOMAIN: &[u8] = b"cait-sith channel tags";
@@ -184,7 +179,27 @@ impl MessageHeader {
     }
 }
 
-type SubMessageQueue = Vec<(Participant, MessageData)>;
+struct SubMessageQueue {
+    sender: futures::channel::mpsc::UnboundedSender<(Participant, MessageData)>,
+    receiver: Arc<Mutex<futures::channel::mpsc::UnboundedReceiver<(Participant, MessageData)>>>,
+}
+
+impl SubMessageQueue {
+    pub fn send(&self, from: Participant, message: MessageData) {
+        // This cannot fail because the receiver is also alive.
+        self.sender.unbounded_send((from, message)).unwrap();
+    }
+}
+
+impl Default for SubMessageQueue {
+    fn default() -> Self {
+        let (sender, receiver) = futures::channel::mpsc::unbounded();
+        Self {
+            sender,
+            receiver: Arc::new(Mutex::new(receiver)),
+        }
+    }
+}
 
 /// A message buffer is a concurrent data structure to buffer messages.
 ///
@@ -195,29 +210,23 @@ type SubMessageQueue = Vec<(Participant, MessageData)>;
 /// until a message for that slot has arrived.
 #[derive(Clone)]
 struct MessageBuffer {
-    messages: Arc<Mutex<HashMap<MessageHeader, SubMessageQueue>>>,
-    events: Arc<Mutex<HashMap<MessageHeader, Event>>>,
+    messages: Arc<std::sync::Mutex<HashMap<MessageHeader, SubMessageQueue>>>,
 }
 
 impl MessageBuffer {
     fn new() -> Self {
         Self {
-            messages: Arc::new(Mutex::new(HashMap::new())),
-            events: Arc::new(Mutex::new(HashMap::new())),
+            messages: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
     }
 
     /// Push a message into this buffer.
     ///
     /// We also need the header for the message, and the participant who sent it.
-    async fn push(&self, header: MessageHeader, from: Participant, message: MessageData) {
-        let mut messages_lock = self.messages.as_ref().lock().await;
-        messages_lock
-            .entry(header)
-            .or_default()
-            .push((from, message));
-        let mut events_lock = self.events.as_ref().lock().await;
-        events_lock.entry(header).or_default().notify(1);
+    fn push(&self, header: MessageHeader, from: Participant, message: MessageData) {
+        let mut messages_lock = self.messages.lock().unwrap();
+        let messages = messages_lock.entry(header).or_default();
+        messages.send(from, message);
     }
 
     /// Pop a message for a particular header.
@@ -225,18 +234,16 @@ impl MessageBuffer {
     /// This will block until a message for that header is available. This will
     /// also correctly wake the underlying task when such a message arrives.
     async fn pop(&self, header: MessageHeader) -> (Participant, MessageData) {
-        loop {
-            let listener = {
-                let mut messages_lock = self.messages.as_ref().lock().await;
-                let messages = messages_lock.entry(header).or_default();
-                if let Some(out) = messages.pop() {
-                    return out;
-                }
-                let mut events_lock = self.events.as_ref().lock().await;
-                events_lock.entry(header).or_default().listen()
-            };
-            listener.await;
-        }
+        let receiver = {
+            let mut messages_lock = self.messages.lock().unwrap();
+            let messages = messages_lock.entry(header).or_default();
+            messages.receiver.clone()
+        };
+        let mut receiver_lock = receiver.lock().await;
+        receiver_lock
+            .next()
+            .await
+            .expect("Reference to sender held")
     }
 }
 
@@ -250,31 +257,25 @@ pub enum Message {
 }
 
 #[derive(Clone)]
-struct Comms {
-    buffer: MessageBuffer,
-    message_s: Sender<Message>,
-    message_r: Receiver<Message>,
+pub struct Comms {
+    incoming: MessageBuffer,
+    outgoing: Arc<std::sync::Mutex<VecDeque<Message>>>,
 }
 
 impl Comms {
     pub fn new() -> Self {
-        let (message_s, message_r) = channel::bounded(1);
-
         Self {
-            buffer: MessageBuffer::new(),
-            message_s,
-            message_r,
+            incoming: MessageBuffer::new(),
+            outgoing: Arc::new(std::sync::Mutex::new(VecDeque::new())),
         }
     }
 
-    async fn outgoing(&self) -> Message {
-        self.message_r
-            .recv()
-            .await
-            .expect("failed to check outgoing messages")
+    fn outgoing(&self) -> Option<Message> {
+        let mut outgoing_lock = self.outgoing.lock().unwrap();
+        outgoing_lock.pop_front()
     }
 
-    async fn push_message(&self, from: Participant, message: MessageData) {
+    fn push_message(&self, from: Participant, message: MessageData) {
         if message.len() < MessageHeader::LEN {
             return;
         }
@@ -284,38 +285,43 @@ impl Comms {
             _ => return,
         };
 
-        self.buffer.push(header, from, message).await
+        self.incoming.push(header, from, message)
     }
 
-    async fn send_raw(&self, data: Message) {
-        self.message_s
-            .send(data)
-            .await
-            .expect("failed to send message");
+    fn send_raw(&self, data: Message) {
+        self.outgoing.lock().unwrap().push_back(data);
     }
 
     /// (Indicate that you want to) send a message to everybody else.
-    async fn send_many<T: Serialize>(&self, header: MessageHeader, data: &T) {
+    fn send_many<T: Serialize>(&self, header: MessageHeader, data: &T) {
         let header_bytes = header.to_bytes();
         let message_data = encode_with_tag(&header_bytes, data);
-        self.send_raw(Message::Many(message_data)).await;
+        self.send_raw(Message::Many(message_data));
     }
 
     /// (Indicate that you want to) send a message privately to someone.
-    async fn send_private<T: Serialize>(&self, header: MessageHeader, to: Participant, data: &T) {
+    fn send_private<T: Serialize>(&self, header: MessageHeader, to: Participant, data: &T) {
         let header_bytes = header.to_bytes();
         let message_data = encode_with_tag(&header_bytes, data);
-        self.send_raw(Message::Private(to, message_data)).await;
+        self.send_raw(Message::Private(to, message_data));
     }
 
     async fn recv<T: DeserializeOwned>(
         &self,
         header: MessageHeader,
     ) -> Result<(Participant, T), ProtocolError> {
-        let (from, data) = self.buffer.pop(header).await;
+        let (from, data) = self.incoming.pop(header).await;
         let decoded: Result<T, Box<dyn error::Error + Send + Sync>> =
             decode(&data[MessageHeader::LEN..]).map_err(|e| e.into());
         Ok((from, decoded?))
+    }
+
+    pub fn private_channel(&self, from: Participant, to: Participant) -> PrivateChannel {
+        PrivateChannel::new(self.clone(), from, to)
+    }
+
+    pub fn shared_channel(&self) -> SharedChannel {
+        SharedChannel::new(self.clone())
     }
 }
 
@@ -338,21 +344,14 @@ impl SharedChannel {
         self.header.next_waitpoint()
     }
 
-    pub async fn send_many<T: Serialize>(&self, waitpoint: Waitpoint, data: &T) {
+    pub fn send_many<T: Serialize>(&self, waitpoint: Waitpoint, data: &T) {
         self.comms
-            .send_many(self.header.with_waitpoint(waitpoint), data)
-            .await
+            .send_many(self.header.with_waitpoint(waitpoint), data);
     }
 
-    pub async fn send_private<T: Serialize>(
-        &self,
-        waitpoint: Waitpoint,
-        to: Participant,
-        data: &T,
-    ) {
+    pub fn send_private<T: Serialize>(&self, waitpoint: Waitpoint, to: Participant, data: &T) {
         self.comms
-            .send_private(self.header.with_waitpoint(waitpoint), to, data)
-            .await
+            .send_private(self.header.with_waitpoint(waitpoint), to, data);
     }
 
     pub async fn recv<T: DeserializeOwned>(
@@ -393,10 +392,9 @@ impl PrivateChannel {
         self.header.next_waitpoint()
     }
 
-    pub async fn send<T: Serialize>(&self, waitpoint: Waitpoint, data: &T) {
+    pub fn send<T: Serialize>(&self, waitpoint: Waitpoint, data: &T) {
         self.comms
-            .send_private(self.header.with_waitpoint(waitpoint), self.to, data)
-            .await
+            .send_private(self.header.with_waitpoint(waitpoint), self.to, data);
     }
 
     pub async fn recv<T: DeserializeOwned>(
@@ -417,157 +415,73 @@ impl PrivateChannel {
     }
 }
 
-/// Represents the context that protocols have access to.
-///
-/// This allows us to spawn new tasks, and send and receive messages.
-///
-/// This context can safely be cloned.
-#[derive(Clone)]
-pub struct Context<'a> {
-    comms: Comms,
-    executor: Arc<Executor<'a>>,
-}
-
-impl<'a> Context<'a> {
-    pub fn new() -> Self {
-        Self {
-            comms: Comms::new(),
-            executor: Arc::new(Executor::new()),
-        }
-    }
-
-    /// Return *the* shared channel for this context.
-    ///
-    /// To get other channels, use the successor function.
-    pub fn shared_channel(&self) -> SharedChannel {
-        SharedChannel::new(self.comms.clone())
-    }
-
-    /// Return *the* private channel for this context.
-    ///
-    /// To get other channels, use the successor function.
-    pub fn private_channel(&self, from: Participant, to: Participant) -> PrivateChannel {
-        PrivateChannel::new(self.comms.clone(), from, to)
-    }
-
-    /// Spawn a new task on the executor.
-    pub fn spawn<T: Send + 'a>(&self, fut: impl Future<Output = T> + Send + 'a) -> Task<T> {
-        self.executor.spawn(fut)
-    }
-
-    /// Run a future to completion on this executor.
-    pub async fn run<T>(&self, fut: impl Future<Output = T>) -> T {
-        self.executor.run(fut).await
-    }
-}
-
 /// This struct will convert a future into a protocol.
-struct ProtocolExecutor<'a, T> {
-    ctx: Context<'a>,
-    ret_r: channel::Receiver<Result<T, ProtocolError>>,
-    cancel_sender: Option<futures::channel::oneshot::Sender<()>>,
-    done: bool,
+struct ProtocolExecutor<T> {
+    comms: Comms,
+    fut: Option<BoxFuture<'static, Result<T, ProtocolError>>>,
+    result: Option<Result<T, ProtocolError>>,
 }
 
-impl<'a, T: Send + 'a> ProtocolExecutor<'a, T> {
+impl<T: Send> ProtocolExecutor<T> {
     fn new(
-        ctx: Context<'a>,
-        fut: impl Future<Output = Result<T, ProtocolError>> + Send + 'a,
+        comms: Comms,
+        fut: impl Future<Output = Result<T, ProtocolError>> + Send + 'static,
     ) -> Self {
-        let (ret_s, ret_r) = smol::channel::bounded(1);
-        let (cancel_sender, cancel_receiver) = futures::channel::oneshot::channel::<()>();
-        let fut = async move {
-            pin!(fut);
-            let res = futures::future::select(fut, cancel_receiver).await;
-            let res = match res {
-                futures::future::Either::Left((res, _)) => res,
-                futures::future::Either::Right(_) => Err(ProtocolError::Cancelled),
-            };
-            ret_s
-                .send(res)
-                .await
-                .expect("failed to return result of protocol");
-        };
-
-        ctx.executor.spawn(fut).detach();
-
         Self {
-            ctx,
-            ret_r,
-            cancel_sender: Some(cancel_sender),
-            done: false,
+            comms,
+            fut: Some(fut.boxed()),
+            result: None,
         }
     }
 }
 
-impl<'a, T> Drop for ProtocolExecutor<'a, T> {
-    fn drop(&mut self) {
-        if let Some(cancel_sender) = self.cancel_sender.take() {
-            cancel_sender.send(()).ok();
-        }
-    }
-}
-
-impl<'a, T> Protocol for ProtocolExecutor<'a, T> {
+impl<T> Protocol for ProtocolExecutor<T> {
     type Output = T;
 
     fn poke(&mut self) -> Result<Action<Self::Output>, ProtocolError> {
-        if self.done {
-            return Ok(Action::Wait);
-        }
-        let fut_return = async {
-            let out = self
-                .ret_r
-                .recv()
-                .await
-                .expect("failed to retrieve return value");
-            Ok::<_, ProtocolError>(Action::Return(out?))
-        };
-        let fut_outgoing = async {
-            let action: Action<Self::Output> = match self.ctx.comms.outgoing().await {
-                Message::Many(m) => Action::SendMany(m),
-                Message::Private(to, m) => Action::SendPrivate(to, m),
-            };
-            Ok::<_, ProtocolError>(action)
-        };
-        // This is a future which will keep ticking the executor until
-        // all tasks are asleep, at which point it will indicate that nothing
-        // is left to do, by returning `Action::Wait`.
-        let fut_wait = async {
-            while self.ctx.executor.try_tick() {
-                // Now that we've ticked, we want to yield to allow the executor to poll
-                // the other action sources.
-                future::yield_now().await;
+        let mut polled_once_already = false;
+        loop {
+            // If there's outgoing messages, request to send them.
+            if let Some(outgoing) = self.comms.outgoing() {
+                return Ok(match outgoing {
+                    Message::Many(m) => Action::SendMany(m),
+                    Message::Private(to, m) => Action::SendPrivate(to, m),
+                });
             }
-            Ok(Action::Wait)
-        };
-        // The priority is first to send all outgoing messages before returning,
-        // otherwise we might deadlock other people, by preventing them from receiving the output.
-        let action = block_on(
-            self.ctx
-                .run(future::or(fut_outgoing, future::or(fut_return, fut_wait))),
-        );
-        match action {
-            Err(_) => self.done = true,
-            Ok(Action::Return(_)) => self.done = true,
-            _ => {}
-        };
-        action
+            // If we already have a return result, return it.
+            if let Some(result) = self.result.take() {
+                return Ok(Action::Return(result?));
+            }
+            // If this is the second iteration, we already polled the future and there's no
+            // progress that can be made.
+            if polled_once_already {
+                return Ok(Action::Wait);
+            }
+            // If we don't have a future, this is an extraneous poke() call, so return Wait.
+            let Some(fut) = self.fut.as_mut() else {
+                return Ok(Action::Wait);
+            };
+            // Now poll the future. It may generate some more messages to send or a return value,
+            // so go back and check all of those again.
+            polled_once_already = true;
+            let waker = noop_waker();
+            let mut cx = Context::from_waker(&waker);
+            if let std::task::Poll::Ready(result) = fut.poll_unpin(&mut cx) {
+                self.result = Some(result);
+                self.fut = None;
+            }
+        }
     }
 
     fn message(&mut self, from: Participant, data: MessageData) {
-        block_on(
-            self.ctx
-                .executor
-                .run(self.ctx.comms.push_message(from, data)),
-        );
+        self.comms.push_message(from, data);
     }
 }
 
 /// Run a protocol, converting a future into an instance of the Protocol trait.
-pub fn make_protocol<'a, T: Send + 'a>(
-    ctx: Context<'a>,
-    fut: impl Future<Output = Result<T, ProtocolError>> + Send + 'a,
-) -> impl Protocol<Output = T> + 'a {
-    ProtocolExecutor::new(ctx, fut)
+pub fn make_protocol<T: Send>(
+    comms: Comms,
+    fut: impl Future<Output = Result<T, ProtocolError>> + Send + 'static,
+) -> impl Protocol<Output = T> {
+    ProtocolExecutor::new(comms, fut)
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -39,8 +39,6 @@ pub enum ProtocolError {
     MalformedSigningKey,
     /// Error in serializing point
     PointSerialization,
-    /// The protocol was cancelled.
-    Cancelled,
     /// Some generic error happened.
     Other(Box<dyn error::Error + Send + Sync>),
 }
@@ -81,7 +79,6 @@ impl fmt::Display for ProtocolError {
             ProtocolError::PointSerialization => {
                 write!(f, "The group element could not be serialized.")
             }
-            ProtocolError::Cancelled => write!(f, "the protocol was cancelled."),
         }
     }
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -81,6 +81,7 @@ impl fmt::Display for ProtocolError {
             ProtocolError::PointSerialization => {
                 write!(f, "The group element could not be serialized.")
             }
+            ProtocolError::Cancelled => write!(f, "the protocol was cancelled."),
         }
     }
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -39,6 +39,8 @@ pub enum ProtocolError {
     MalformedSigningKey,
     /// Error in serializing point
     PointSerialization,
+    /// The protocol was cancelled.
+    Cancelled,
     /// Some generic error happened.
     Other(Box<dyn error::Error + Send + Sync>),
 }


### PR DESCRIPTION
Cait sith algorithms are written with async functions; this is a great design pattern because it allows logic to be written in a syntactically synchronous way while allowing asynchrous execution. The exposed interface `Protocol<T>` provides the `poke()` and `message()` functions: `poke()` executes the async computation until hitting a yield point, and `message()` provides additional input that may unblock further execution of the computation.

Unfortunately, the previous implementation used Executor which provided an additional layer of complexity; there were various `block_on` calls which were difficult to reason about. It appears that the reason why an Executor was used was to allow spawning additional futures during the computation in order to parallelize certain message-receiving wait points. This is not a great design pattern, because:
* Futures that are spawned onto the executor internally hold a reference to the executor itself (via `Arc<Executor>`); yet, the Executor also owns these futures. That means if these futures do not exit, it is impossible to clean up the Executor due to a circular reference. It is not enough to simply return in the top-level future due to these extra spawned futures.
* Spawning extra futures encourages an irresponsible practice of simply spawning a future in order to parallelize it, which is used in various places in the code, mostly in a for loop. The exception is in triple generation that has a multiplication task spawned earlier in the computation and joined later.

This PR removes the Executor usage, and remove places where asynchrony is actually fruitless:
* `poke()` essentially just calls `Future::poll` now - the right way that a future should be executed. We pass in a no-op waker context, because we don't rely on the waking mechanism - waking is explicitly performed by the code that pokes the protocol in a loop.
* Dropping the protocol is guaranteed to drop the future and associated resources, because there is no circular reference (no spawned futures, no executor; the future is owned by the Protocol directly)
* All spawns are replaced by `join` or `join_all`.
* Reimplemented the message queues. The incoming message queue was not only complex before, but I'm also not sure if it's implemented correctly. Now it just uses unbounded channels. The outgoing message queue is not even async anymore, just a VecDeque in a mutex.
* As a result, `send_*` functions are now synchronous... because... they should be. They don't need to wait on anything at all.

All tests on cait-sith and mpc side pass.